### PR TITLE
Dockerize Java Application with Spring and Create Docker Compose with MySQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:21-jdk-slim
+
+WORKDIR /app
+
+COPY target/vetdata-0.0.1-SNAPSHOT.jar /app/vetdata.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/vetdata.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.9"
+
+services:
+  mysql:
+    image: mysql:latest
+    container_name: vetdata_db
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: vetdata
+    volumes:
+      - vetdata_mysql_volume:/var/lib/mysql
+    ports:
+      - "3307:3306"
+    networks:
+      - vetdata-network
+
+  vetdata-app:
+    build: .
+    container_name: vetdata_app
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://vetdata_db:3306/vetdata
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: root
+    depends_on:
+      - mysql
+    networks:
+      - vetdata-network
+
+networks:
+  vetdata-network:
+
+volumes:
+  vetdata_mysql_volume:


### PR DESCRIPTION
# Dockerize Java Application with Spring and Create Docker Compose with MySQL

## Type
- [ ] Hot fix
- [x] New feature
- [ ] Refactor / Improvements

## Context
- Criado o DockerFile, para criar a imagem com as variáveis de ambiente que usamos na nossa aplicação.
- Criado o Docker Compose, para conseguir gerenciar nossos conteiners MySQL e Vetdata, fazendo com que eles consigam se comunicar e funcionar juntos.

### Checklist
- [x] Crie um Dockerfile para a Aplicação Java com Spring (VetData).
- [x] Crie um arquivo docker-compose.yml para que possamos subir tanto a nossa app quanto o mysql via docker.