### PR TITLE
Add create user in schema.sql script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,11 @@ services:
     command: [ "sh", "-c", "
             docker-entrypoint.sh mysqld & 
             echo 'Aguardando MySQL iniciar...'; 
-            until mysql -uvetuser -pvetpass -h 127.0.0.1 -e 'SELECT 1' &> /dev/null; do
+            until mysql -uroot -proot -h 127.0.0.1 -e 'SELECT 1' &> /dev/null; do
               sleep 2;
             done;
             echo 'Executando schema.sql...';
-            mysql -uvetuser -pvetpass < /docker-entrypoint-initdb.d/schema.sql;
+            mysql -uroot -proot < /docker-entrypoint-initdb.d/schema.sql;
             wait" ]
     ports:
       - "3307:3306"

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -1,5 +1,11 @@
 CREATE DATABASE IF NOT EXISTS vetdata;
+
 USE vetdata;
+
+DROP USER IF EXISTS 'vetuser'@'%';
+CREATE USER  'vetuser'@'%' IDENTIFIED BY 'vetpass';
+GRANT ALL PRIVILEGES ON vetdata.* TO 'vetuser'@'%';
+FLUSH PRIVILEGES;
 
 CREATE TABLE IF NOT EXISTS post_operative (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
@@ -55,7 +61,7 @@ CREATE TABLE IF NOT EXISTS hospital_admission (
     date_return DATE,
     medical_evolution VARCHAR(20),
     treatment_next_steps TEXT,
-    health_record_id BIGINT UNSIGNED,
+    health_record_id BIGINT UNSIGNED NOT NULL,
     CONSTRAINT fk_health_record_id FOREIGN KEY (health_record_id)
 		REFERENCES health_record(id) ON DELETE CASCADE
 ) ENGINE=InnoDB AUTO_INCREMENT=1421 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.username=vetuser
 spring.datasource.password=vetpass
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 


### PR DESCRIPTION
## Type
- [ ] Hotfix
- [x] New feature
- [ ] Refactor / Improvements

## Context

Precisamos alterar o arquivo schema.sql  responsável localmente pela criação da base de dados da app vetdata para criar o usuário da aplicação toda vez que o script fosse executado.

Sem o usuário criado, a app não consegue se conectar ao banco de dados.

## Coverage Tests

Não foi alterado cobertura de teste.

## Tests

### Antes da execução do script:

![Captura de tela de 2025-03-24 20-10-57](https://github.com/user-attachments/assets/24a526d5-49b3-452e-bc39-6d7cbb96c136)

### Após a execução do script:

![Captura de tela de 2025-03-24 20-16-21](https://github.com/user-attachments/assets/51b09df6-4f4b-4f34-b472-a75adff4197d)
