### PR TITLE
Health Record Get By Id

### DIFF
--- a/src/main/java/com/project/vetdata/controller/HealthRecordController.java
+++ b/src/main/java/com/project/vetdata/controller/HealthRecordController.java
@@ -120,4 +120,23 @@ public class HealthRecordController {
         healthRecordService.deleteHealthRecord(record.getId());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
+
+    @Operation(summary = "Buscar prontuário pelo ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Prontuário encontrado!",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = HealthRecordResponseDTO.class))}),
+            @ApiResponse(responseCode = "400", description = "ID inválido!", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Prontuário não encontrado!", content = @Content)
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getHealthRecordById(@PathVariable Long id) {
+        return healthRecordService.getHealthRecordById(id)
+                .map(this::convertToResponseEntity)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    private ResponseEntity<?> convertToResponseEntity(HealthRecord record) {
+        return ResponseEntity.ok(new HealthRecordResponseDTO(record));
+    }
 }

--- a/src/test/java/com/project/vetdata/controller/HealthRecordControllerIT.java
+++ b/src/test/java/com/project/vetdata/controller/HealthRecordControllerIT.java
@@ -479,4 +479,53 @@ public class HealthRecordControllerIT {
         assertEquals("Cookie", existingRecord.getPatient());
         assertEquals("Aline", existingRecord.getTutor());
     }
+
+    @Test
+    public void given_valid_id_when_getHealthRecordById_then_returns_healthRecord() {
+        DogBreed dogBreed = new DogBreed(null, "2", "Pug", "Amigável e inteligente e esperto",
+                10, 12, 30D, 34D, 25D, 29D, false, "Medio");
+        DogBreed savedBreed = dogBreedRepository.save(dogBreed);
+
+        HealthRecord record = new HealthRecord();
+        record.setCodPatient("P789");
+        record.setTutor("Aline");
+        record.setPatient("Cookie");
+        record.setBreed(savedBreed);
+        record.setAge(7.0);
+        record.setWeight(30.0);
+        record.setColor("Branco");
+        record.setSize(DogSize.SMALL);
+        record.setGender(Gender.FEMALE);
+        record.setDeath(false);
+        record.setEuthanasia(Euthanasia.NO);
+        record.setAdmission(LocalDate.of(2025, 3, 15));
+        HealthRecord savedRecord = healthRecordRepository.save(record);
+
+        given()
+                .pathParam("id", savedRecord.getId())
+                .when()
+                .get("/health-records/{id}")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(savedRecord.getId().intValue()))
+                .body("patient", equalTo("Cookie"))
+                .body("tutor", equalTo("Aline"))
+                .body("codPatient", equalTo("P789"))
+                .body("breedId", equalTo(savedBreed.getId().intValue()))
+                .body("gender", equalTo("FEMALE"))
+                .body("size", equalTo("SMALL"))
+                .body("color", equalTo("Branco"))
+                .body("age", equalTo(7.0F))
+                .body("weight", equalTo(30.0F));
+    }
+
+    @Test
+    public void given_non_existent_id_when_getHealthRecordById_then_returns_notFound() {
+        given()
+                .pathParam("id", 99L)
+                .when()
+                .get("/health-records/{id}")
+                .then()
+                .statusCode(404);
+    }
 }

--- a/src/test/java/com/project/vetdata/controller/HealthRecordControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/HealthRecordControllerTest.java
@@ -284,4 +284,31 @@ public class HealthRecordControllerTest {
         mockMvc.perform(delete("/health-records/{id}", invalidId))
                 .andExpect(status().isNotFound());
     }
+
+    @Test
+    public void given_existing_heathRecordId_when_getHealthRecordById_then_returns_record() throws Exception{
+        Long healthRecordId = 1L;
+        HealthRecord existingRecord = new HealthRecord(healthRecordId, LocalDate.of(2025, 2, 20),
+                4.0,"C357","Preto", false, Euthanasia.NO, Gender.MALE, "Nutella", DogSize.MEDIUM, "Clovis", 12.0,
+                new DogBreed(1L, "001", "Labrador", "Companheiro", 10, 12,
+                        25.0, 30.0, 22.0, 28.0, false, "Médio"));
+
+        when(healthRecordService.getHealthRecordById(healthRecordId)).thenReturn(Optional.of(existingRecord));
+
+        mockMvc.perform(get("/health-records/{id}", healthRecordId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(healthRecordId))
+                .andExpect(jsonPath("$.patient").value("Nutella"));
+
+    }
+
+    @Test
+    public void given_nonexistent_healthRecordId_when_getHealthRecordById_then_returns_notFound() throws Exception {
+        Long id = 999L;
+
+        when(healthRecordService.getHealthRecordById(id)).thenThrow(new EntityNotFoundException("Prontuário não encontrado"));
+
+        mockMvc.perform(get("/health-records/{id}", id))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/src/test/java/com/project/vetdata/service/HealthRecordServiceImplIT.java
+++ b/src/test/java/com/project/vetdata/service/HealthRecordServiceImplIT.java
@@ -247,6 +247,28 @@ public class HealthRecordServiceImplIT {
         }
     }
 
+    @Test
+    public void given_existing_healthRecord_when_getHealthRecordById_then_returns_heathRecord() {
+        DogBreed breed = dogBreedRepository.save(createFakeBreed());
+        HealthRecordCreateDTO createDTO = getFakeHealthRecordDTO(breed.getId());
+        HealthRecord created = healthRecordService.createHealthRecord(createDTO);
+
+        Optional<HealthRecord> result = healthRecordService.getHealthRecordById(created.getId());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(created.getId());
+        assertThat(result.get().getPatient()).isEqualTo(created.getPatient());
+    }
+
+    @Test
+    public void given_non_existing_healthRecord_when_getHealthRecordById_then_returns_empty_optional() {
+        Long nonExistenId = 99L;
+
+        Optional<HealthRecord> result = healthRecordService.getHealthRecordById(nonExistenId);
+
+        assertThat(result).isNotPresent();
+    }
+
     private DogBreed createFakeBreed() {
         DogBreed breed = new DogBreed();
         breed.setName("Golden Retriever");

--- a/src/test/java/com/project/vetdata/service/HealthRecordServiceImplTest.java
+++ b/src/test/java/com/project/vetdata/service/HealthRecordServiceImplTest.java
@@ -189,6 +189,30 @@ public class HealthRecordServiceImplTest {
         verify(healthRecordRepository, times(1)).deleteById(invalidHealthRecordId);
     }
 
+    @Test
+    public void given_valid_id_when_getHealthRecordById_is_called_then_healthRecord_is_returned() {
+        Long id = 1L;
+        HealthRecord record = getFakeHealthRecord();
+
+        when(healthRecordRepository.findById(id)).thenReturn(Optional.of(record));
+
+        Optional<HealthRecord> result = healthRecordService.getHealthRecordById(id);
+
+        assertTrue(result.isPresent(), "O protuário deve ser encontrado");
+        assertEquals(record.getPatient(), result.get().getPatient(), "O nome do paciente deve ser igual");
+    }
+
+    @Test
+    public void given_invalid_is_when_getHealthRecordById_is_called_optional_empty_is_returned() {
+        Long id = 99L;
+
+        when(healthRecordRepository.findById(id)).thenReturn(Optional.empty());
+
+        Optional<HealthRecord> result = healthRecordService.getHealthRecordById(id);
+
+        assertFalse(result.isPresent(), "O prontuário não deve ser encontrado");
+    }
+
     private HealthRecordCreateDTO getFakeHealthRecordCreateDTO() {
         HealthRecordCreateDTO dto = new HealthRecordCreateDTO();
         dto.setCodPatient("P01");


### PR DESCRIPTION
# Health Record Get By Id

## Type
- [ ] Hotfix
- [x] New feature
- [ ] Refactor / Improvements

## Context
- Adicionado o serviço de busca de prontuário por ID.
- Criado o endpoint GET /health-records/{id} para recuperar os dados de um prontuário específico.

### Coverage Tests
![2](https://github.com/user-attachments/assets/51c22ef4-5c28-4c7c-ba61-f247ed889006)


### Checklist
- [x] Implementar a funcionalidade de busca por ID.
- [x] Criar documentação no Swagger.
- [x] Criar testes automatizados.