### PR TITLE
Implement listing functionality for hospital admission

### DIFF
--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -36,7 +36,6 @@ CREATE TABLE IF NOT EXISTS `dog_breeds` (
 
 CREATE TABLE IF NOT EXISTS health_record (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    admission DATE NOT NULL,
     age DOUBLE UNSIGNED,
     cod_patient VARCHAR(255),
     color VARCHAR(255),

--- a/src/main/java/com/project/vetdata/controller/HospitalAdmissionController.java
+++ b/src/main/java/com/project/vetdata/controller/HospitalAdmissionController.java
@@ -11,9 +11,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/hospital-admission")
@@ -25,7 +29,7 @@ public class HospitalAdmissionController {
         this.hospitalAdmissionService = hospitalAdmissionService;
     }
 
-    @Operation(summary = "Criar uma nova internação hospitalar")
+    @Operation(summary = "Criar uma nova internação")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Internação criada com sucesso!",
                     content = {@Content(mediaType = "application/json",
@@ -54,5 +58,17 @@ public class HospitalAdmissionController {
 
         HospitalAdmissionResponseDTO updated = hospitalAdmissionService.updateHospitalAdmission(id, dto);
         return ResponseEntity.ok(updated);
+    }
+
+    @Operation(summary = "Listar todas as internações")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista de internações retornada com sucesso!",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = HospitalAdmission.class))})
+    })
+    @GetMapping
+    public ResponseEntity<List<HospitalAdmissionResponseDTO>> getAllHospitalAdmission() {
+        List<HospitalAdmissionResponseDTO> admissions = hospitalAdmissionService.findAll();
+        return  ResponseEntity.ok(admissions);
     }
 }

--- a/src/main/java/com/project/vetdata/dto/HealthRecordCreateDTO.java
+++ b/src/main/java/com/project/vetdata/dto/HealthRecordCreateDTO.java
@@ -12,7 +12,6 @@ import java.time.LocalDate;
 
 public class HealthRecordCreateDTO {
 
-    private LocalDate admission;
     private Double age;
     private String codPatient;
     private String color;
@@ -28,10 +27,9 @@ public class HealthRecordCreateDTO {
     public HealthRecordCreateDTO() {
     }
 
-    public HealthRecordCreateDTO(LocalDate admission, Double age, String codPatient, String color, Boolean death,
+    public HealthRecordCreateDTO(Double age, String codPatient, String color, Boolean death,
                                  Euthanasia euthanasia, Gender gender, String patient, DogSize size,
                                  String tutor, Double weight, Long breedId) {
-        this.admission = admission;
         this.age = age;
         this.codPatient = codPatient;
         this.color = color;
@@ -43,12 +41,6 @@ public class HealthRecordCreateDTO {
         this.tutor = tutor;
         this.weight = weight;
         this.breedId = breedId;
-    }
-
-    @NotNull(message = "Campo Obrigatório")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy")
-    public LocalDate getAdmission() {
-        return admission;
     }
 
     @Min(value = 0, message = "Campo deve ser maior que 0")
@@ -101,10 +93,6 @@ public class HealthRecordCreateDTO {
     @NotNull(message = "Campo Obrigatório")
     public Long getBreedId() {
         return breedId;
-    }
-
-    public void setAdmission(LocalDate admission) {
-        this.admission = admission;
     }
 
     public void setAge(Double age) {

--- a/src/main/java/com/project/vetdata/dto/HealthRecordResponseDTO.java
+++ b/src/main/java/com/project/vetdata/dto/HealthRecordResponseDTO.java
@@ -17,7 +17,6 @@ public class HealthRecordResponseDTO {
     private String color;
     private Double age;
     private Double weight;
-    private LocalDate admission;
     private DogSize size;
     private Gender gender;
     private Boolean death;
@@ -37,7 +36,6 @@ public class HealthRecordResponseDTO {
         this.color = entity.getColor();
         this.age = entity.getAge();
         this.weight = entity.getWeight();
-        this.admission = entity.getAdmission();
         this.size = entity.getSize();
         this.gender = entity.getGender();
         this.death = entity.getDeath();
@@ -74,10 +72,6 @@ public class HealthRecordResponseDTO {
 
     public Double getWeight() {
         return weight;
-    }
-
-    public LocalDate getAdmission() {
-        return admission;
     }
 
     public DogSize getSize() {

--- a/src/main/java/com/project/vetdata/dto/HealthRecordUpdateDTO.java
+++ b/src/main/java/com/project/vetdata/dto/HealthRecordUpdateDTO.java
@@ -12,7 +12,6 @@ import java.time.LocalDate;
 
 public class HealthRecordUpdateDTO {
 
-    private LocalDate admission;
     private Double age;
     private String codPatient;
     private String color;
@@ -28,9 +27,8 @@ public class HealthRecordUpdateDTO {
     public HealthRecordUpdateDTO() {
     }
 
-    public HealthRecordUpdateDTO(LocalDate admission, Double age, String codPatient, String color, Boolean death, Euthanasia euthanasia, Gender gender, String patient,
+    public HealthRecordUpdateDTO(Double age, String codPatient, String color, Boolean death, Euthanasia euthanasia, Gender gender, String patient,
                                  DogSize size, String tutor, Double weight, Long breedId) {
-        this.admission = admission;
         this.age = age;
         this.codPatient = codPatient;
         this.color = color;
@@ -42,12 +40,6 @@ public class HealthRecordUpdateDTO {
         this.tutor = tutor;
         this.weight = weight;
         this.breedId = breedId;
-    }
-
-    @NotNull(message = "Campo Obrigatório")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy")
-    public LocalDate getAdmission() {
-        return admission;
     }
 
     @Min(value = 0, message = "Campo deve ser maior que 0")
@@ -100,10 +92,6 @@ public class HealthRecordUpdateDTO {
     @NotNull(message = "Campo Obrigatório")
     public Long getBreedId() {
         return breedId;
-    }
-
-    public void setAdmission(LocalDate admission) {
-        this.admission = admission;
     }
 
     public void setAge(Double age) {

--- a/src/main/java/com/project/vetdata/dto/HospitalAdmissionResponseDTO.java
+++ b/src/main/java/com/project/vetdata/dto/HospitalAdmissionResponseDTO.java
@@ -112,5 +112,4 @@ public class HospitalAdmissionResponseDTO {
     public void setPostOperativeIds(Set<Long> postOperativeIds) {
         this.postOperativeIds = postOperativeIds;
     }
-
 }

--- a/src/main/java/com/project/vetdata/model/HealthRecord.java
+++ b/src/main/java/com/project/vetdata/model/HealthRecord.java
@@ -17,8 +17,6 @@ public class HealthRecord {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private LocalDate admission;
-
     private Double age;
 
     @Column(name = "cod_patient")
@@ -50,11 +48,10 @@ public class HealthRecord {
     public HealthRecord() {
     }
 
-    public HealthRecord(Long id, LocalDate admission, Double age, String codPatient, String color, boolean death,
+    public HealthRecord(Long id, Double age, String codPatient, String color, boolean death,
                         Euthanasia euthanasia, Gender gender, String patient, DogSize size, String tutor,
                         Double weight, DogBreed breed) {
         this.id = id;
-        this.admission = admission;
         this.age = age;
         this.codPatient = codPatient;
         this.color = color;
@@ -72,9 +69,6 @@ public class HealthRecord {
         return id;
     }
 
-    public LocalDate getAdmission() {
-        return admission;
-    }
 
     public Double getAge() {
         return age;
@@ -118,10 +112,6 @@ public class HealthRecord {
 
     public DogBreed getBreed() {
         return breed;
-    }
-
-    public void setAdmission(LocalDate admission) {
-        this.admission = admission;
     }
 
     public void setAge(Double age) {

--- a/src/main/java/com/project/vetdata/service/HealthRecordServiceImpl.java
+++ b/src/main/java/com/project/vetdata/service/HealthRecordServiceImpl.java
@@ -33,7 +33,7 @@ public class HealthRecordServiceImpl implements HealthRecordService {
                 .orElseThrow(() -> new IllegalArgumentException("Raça " + dto.getBreedId() + " não encontrada"));
 
         HealthRecord record = new HealthRecord();
-        record.setAdmission(dto.getAdmission());
+
         record.setAge(dto.getAge());
         record.setCodPatient(dto.getCodPatient());
         record.setColor(dto.getColor());
@@ -51,9 +51,6 @@ public class HealthRecordServiceImpl implements HealthRecordService {
 
     public HealthRecord updateHealthRecord(Long id, HealthRecordUpdateDTO dto) {
         return healthRecordRepository.findById(id).map(existingRecord -> {
-            if (dto.getAdmission() != null) {
-                existingRecord.setAdmission(dto.getAdmission());
-            }
             if (dto.getAge() != null) {
                 existingRecord.setAge(dto.getAge());
             }

--- a/src/main/java/com/project/vetdata/service/HospitalAdmissionService.java
+++ b/src/main/java/com/project/vetdata/service/HospitalAdmissionService.java
@@ -5,8 +5,13 @@ import com.project.vetdata.dto.HospitalAdmissionCreateDTO;
 import com.project.vetdata.dto.HospitalAdmissionResponseDTO;
 import com.project.vetdata.dto.HospitalAdmissionUpdateDTO;
 import com.project.vetdata.model.HospitalAdmission;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface HospitalAdmissionService {
     HospitalAdmissionResponseDTO createHospitalAdmission(HospitalAdmissionCreateDTO dto);
     HospitalAdmissionResponseDTO updateHospitalAdmission(Long id, HospitalAdmissionUpdateDTO dto);
+    List<HospitalAdmissionResponseDTO> findAll();
 }

--- a/src/main/java/com/project/vetdata/service/HospitalAdmissionServiceImpl.java
+++ b/src/main/java/com/project/vetdata/service/HospitalAdmissionServiceImpl.java
@@ -11,10 +11,13 @@ import com.project.vetdata.repository.DiagnosticRepository;
 import com.project.vetdata.repository.HealthRecordRepository;
 import com.project.vetdata.repository.HospitalAdmissionRepository;
 import com.project.vetdata.repository.PostOperativeRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -145,5 +148,13 @@ public class HospitalAdmissionServiceImpl implements HospitalAdmissionService {
 
         HospitalAdmission updated = hospitalAdmissionRepository.save(existing);
         return mapToResponse(updated);
+    }
+
+    @Override
+    public List<HospitalAdmissionResponseDTO> findAll() {
+        List<HospitalAdmission> admissions = hospitalAdmissionRepository.findAll();
+        return admissions.stream()
+                .map(this::mapToResponse)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/project/vetdata/controller/HealthRecordControllerIT.java
+++ b/src/test/java/com/project/vetdata/controller/HealthRecordControllerIT.java
@@ -101,7 +101,6 @@ public class HealthRecordControllerIT {
         dto.setGender(Gender.MALE);
         dto.setDeath(false);
         dto.setEuthanasia(Euthanasia.NO);
-        dto.setAdmission(LocalDate.of(2025, 1, 1));
 
         Long createdId =
                 given()
@@ -142,7 +141,6 @@ public class HealthRecordControllerIT {
         dto.setGender(Gender.MALE);
         dto.setDeath(null);
         dto.setEuthanasia(Euthanasia.NO);
-        dto.setAdmission(null);
 
         given()
                 .contentType("application/json")
@@ -174,7 +172,6 @@ public class HealthRecordControllerIT {
         record.setGender(Gender.MALE);
         record.setDeath(false);
         record.setEuthanasia(Euthanasia.NO);
-        record.setAdmission(LocalDate.of(2025, 4, 11));
         HealthRecord savedRecord = healthRecordRepository.save(record);
 
         savedRecord.getBreed().getName();
@@ -191,7 +188,6 @@ public class HealthRecordControllerIT {
         updateDTO.setGender(Gender.MALE);
         updateDTO.setDeath(false);
         updateDTO.setEuthanasia(Euthanasia.NO);
-        updateDTO.setAdmission(LocalDate.of(2025, 2, 1));
 
         given()
                 .pathParam("id", savedRecord.getId())
@@ -218,7 +214,6 @@ public class HealthRecordControllerIT {
         assertEquals("Bege", updated.getColor());
         assertEquals(6.0, updated.getAge());
         assertEquals(29.0, updated.getWeight());
-        assertEquals(LocalDate.of(2025, 2, 1), updated.getAdmission());
     }
 
     @Test
@@ -239,7 +234,6 @@ public class HealthRecordControllerIT {
         record.setGender(Gender.MALE);
         record.setDeath(false);
         record.setEuthanasia(Euthanasia.NO);
-        record.setAdmission(LocalDate.of(2025, 4, 11));
         HealthRecord savedRecord = healthRecordRepository.save(record);
 
 
@@ -255,7 +249,6 @@ public class HealthRecordControllerIT {
         updateDTO.setGender(Gender.MALE);
         updateDTO.setDeath(false);
         updateDTO.setEuthanasia(Euthanasia.NO);
-        updateDTO.setAdmission(LocalDate.of(2025, 2, 1));
 
         given()
                 .pathParam("id", "abc")
@@ -276,7 +269,6 @@ public class HealthRecordControllerIT {
         assertEquals("Marrom", original.getColor());
         assertEquals(5.0, original.getAge());
         assertEquals(28.0, original.getWeight());
-        assertEquals(LocalDate.of(2025, 4, 11), original.getAdmission());
     }
 
     @Test
@@ -297,7 +289,6 @@ public class HealthRecordControllerIT {
         record.setGender(Gender.MALE);
         record.setDeath(false);
         record.setEuthanasia(Euthanasia.NO);
-        record.setAdmission(LocalDate.of(2025, 4, 11));
         HealthRecord savedRecord = healthRecordRepository.save(record);
 
 
@@ -313,7 +304,6 @@ public class HealthRecordControllerIT {
         updateDTO.setGender(Gender.MALE);
         updateDTO.setDeath(false);
         updateDTO.setEuthanasia(Euthanasia.NO);
-        updateDTO.setAdmission(LocalDate.of(2025, 2, 1));
 
         given()
                 .pathParam("id", 999L)
@@ -334,7 +324,6 @@ public class HealthRecordControllerIT {
         assertEquals("Marrom", original.getColor());
         assertEquals(5.0, original.getAge());
         assertEquals(28.0, original.getWeight());
-        assertEquals(LocalDate.of(2025, 4, 11), original.getAdmission());
     }
 
     @Test
@@ -355,7 +344,6 @@ public class HealthRecordControllerIT {
         record1.setGender(Gender.MALE);
         record1.setDeath(false);
         record1.setEuthanasia(Euthanasia.NO);
-        record1.setAdmission(LocalDate.of(2025, 4, 11));
         HealthRecord savedRecord1 = healthRecordRepository.save(record1);
 
         HealthRecord record2 = new HealthRecord();
@@ -370,7 +358,6 @@ public class HealthRecordControllerIT {
         record2.setGender(Gender.FEMALE);
         record2.setDeath(true);
         record2.setEuthanasia(Euthanasia.YES);
-        record2.setAdmission(LocalDate.of(2025, 4, 10));
         HealthRecord savedRecord2 = healthRecordRepository.save(record2);
 
         when()
@@ -432,7 +419,6 @@ public class HealthRecordControllerIT {
         record.setGender(Gender.FEMALE);
         record.setDeath(false);
         record.setEuthanasia(Euthanasia.NO);
-        record.setAdmission(LocalDate.of(2025, 3, 15));
         HealthRecord savedRecord = healthRecordRepository.save(record);
 
         given()
@@ -464,7 +450,6 @@ public class HealthRecordControllerIT {
         record.setGender(Gender.FEMALE);
         record.setDeath(false);
         record.setEuthanasia(Euthanasia.NO);
-        record.setAdmission(LocalDate.of(2025, 3, 15));
         HealthRecord savedRecord = healthRecordRepository.save(record);
 
         given()
@@ -498,7 +483,6 @@ public class HealthRecordControllerIT {
         record.setGender(Gender.FEMALE);
         record.setDeath(false);
         record.setEuthanasia(Euthanasia.NO);
-        record.setAdmission(LocalDate.of(2025, 3, 15));
         HealthRecord savedRecord = healthRecordRepository.save(record);
 
         given()

--- a/src/test/java/com/project/vetdata/controller/HealthRecordControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/HealthRecordControllerTest.java
@@ -50,11 +50,9 @@ public class HealthRecordControllerTest {
 
     @Test
     public void given_valid_healthRecord_when_createHealthRecord_then_returns_createdHealthRecord() throws Exception {
-        HealthRecordCreateDTO dto = new HealthRecordCreateDTO(LocalDate.of(2024, 4, 9), 3.5, "C123", "Preto", false,
-                Euthanasia.NO, Gender.MALE, "Torresmo", DogSize.SMALL, "Cleyton", 12.0, 1L
-        );
+        HealthRecordCreateDTO dto = new HealthRecordCreateDTO(3.5, "C123", "Preto", false, Euthanasia.NO, Gender.MALE, "Torresmo", DogSize.SMALL, "Cleyton", 12.0, 1L);
 
-        HealthRecord savedRecord = new HealthRecord(10L, dto.getAdmission(), dto.getAge(), dto.getCodPatient(), dto.getColor(), dto.getDeath(), dto.getEuthanasia(),
+        HealthRecord savedRecord = new HealthRecord(10L, dto.getAge(), dto.getCodPatient(), dto.getColor(), dto.getDeath(), dto.getEuthanasia(),
                 dto.getGender(), dto.getPatient(), dto.getSize(), dto.getTutor(), dto.getWeight(), new DogBreed(1L, "123", "Labrador",
                 "Amigavel e Corajoso", 8, 10, 20.0, 25.0, 18.0, 23.0,
                 false,"Médio"));
@@ -74,7 +72,6 @@ public class HealthRecordControllerTest {
     @Test
     public void given_invalid_healthRecord_when_createHealthRecord_then_returnsBadRequest() throws Exception {
         HealthRecordCreateDTO dto = new HealthRecordCreateDTO();
-        dto.setAdmission(null);
         dto.setAge(-1.0);
         dto.setCodPatient("");
         dto.setColor("");
@@ -91,7 +88,6 @@ public class HealthRecordControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.admission").value("Campo Obrigatório"))
                 .andExpect(jsonPath("$.euthanasia").value("Campo Obrigatório"))
                 .andExpect(jsonPath("$.gender").value("Campo Obrigatório"))
                 .andExpect(jsonPath("$.patient").value("Campo Obrigatório"))
@@ -104,14 +100,13 @@ public class HealthRecordControllerTest {
     @Test
     public void given_healthRecord_exists_and_is_updated_when_updateHealthRecord_then_returns_updatedRecord() throws Exception {
         HealthRecordUpdateDTO updateDTO = new HealthRecordUpdateDTO(
-                LocalDate.of(2024, 4, 10), 4.5, "P145", "Branco",
+                4.5, "P145", "Branco",
                 false, Euthanasia.NO, Gender.FEMALE, "Cacau", DogSize.MEDIUM,
                 "Andrea", 14.0, 2L
         );
 
         HealthRecord updatedRecord = new HealthRecord(
                 123L,
-                updateDTO.getAdmission(),
                 updateDTO.getAge(),
                 updateDTO.getCodPatient(),
                 updateDTO.getColor(),
@@ -145,14 +140,12 @@ public class HealthRecordControllerTest {
                 .andExpect(jsonPath("$.gender").value("FEMALE"))
                 .andExpect(jsonPath("$.size").value("MEDIUM"))
                 .andExpect(jsonPath("$.weight").value(14.0))
-                .andExpect(jsonPath("$.death").value(false))
-                .andExpect(jsonPath("$.admission").value("2024-04-10"));
+                .andExpect(jsonPath("$.death").value(false));
     }
 
     @Test
     public void given_invalid_healthRecord_when_updateHealthRecord_then_returnsBadRequest() throws Exception {
         HealthRecordUpdateDTO updateDTO = new HealthRecordUpdateDTO();
-        updateDTO.setAdmission(null);
         updateDTO.setAge(-2.0);
         updateDTO.setCodPatient("");
         updateDTO.setColor("");
@@ -169,7 +162,6 @@ public class HealthRecordControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(updateDTO)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.admission").value("Campo Obrigatório"))
                 .andExpect(jsonPath("$.euthanasia").value("Campo Obrigatório"))
                 .andExpect(jsonPath("$.gender").value("Campo Obrigatório"))
                 .andExpect(jsonPath("$.patient").value("Campo Obrigatório"))
@@ -181,7 +173,7 @@ public class HealthRecordControllerTest {
 
     @Test
     public void given_healthRecordDoesNotExist_when_updateHealthRecord_then_returnsNotFound() throws Exception {
-        HealthRecordUpdateDTO updateDTO = new HealthRecordUpdateDTO(LocalDate.of(2024, 4, 10), 4.5, "C456", "Branco",
+        HealthRecordUpdateDTO updateDTO = new HealthRecordUpdateDTO(4.5, "C456", "Branco",
                 false, Euthanasia.NO, Gender.FEMALE, "Cookie", DogSize.MEDIUM, "Aline", 14.0, 2L);
 
         when(healthRecordService.updateHealthRecord(eq(999L), any(HealthRecordUpdateDTO.class)))
@@ -196,11 +188,11 @@ public class HealthRecordControllerTest {
     @Test
     public void given_pageRequestAndHealthRecordsExist_when_getHealthRecordsPage_then_returnsHealthRecordsPage() throws Exception {
         List<HealthRecord> records = List.of(
-                new HealthRecord(1L, LocalDate.of(2024, 4, 1), 3.0, "C001", "Preto", false, Euthanasia.NO,
+                new HealthRecord(1L, 3.0, "C001", "Preto", false, Euthanasia.NO,
                         Gender.FEMALE, "Cacau", DogSize.SMALL, "Andrea", 10.0,
                         new DogBreed(1L, "001", "Beagle", "Curioso", 10, 12,
                                 10.0, 15.0, 8.0, 12.0, false, "Pequeno")),
-                new HealthRecord(2L, LocalDate.of(2024, 4, 2), 4.0, "C002", "Marrom", false, Euthanasia.NO,
+                new HealthRecord(2L, 4.0, "C002", "Marrom", false, Euthanasia.NO,
                         Gender.MALE, "Nutella", DogSize.MEDIUM, "Aline", 14.0,
                         new DogBreed(2L, "002", "Boxer", "Brincalhão", 9, 11,
                                 25.0, 32.0, 22.0, 30.0, false, "Médio"))
@@ -235,7 +227,7 @@ public class HealthRecordControllerTest {
     @Test
     public void given_search_parameter_when_get_healthRecords_page_then_returns_filtered_healthRecords_page() throws Exception {
         List<HealthRecord> filteredRecords = List.of(
-                new HealthRecord(3L, LocalDate.of(2024, 4, 5), 2.0, "C003", "Branco", false, Euthanasia.NO,
+                new HealthRecord(3L, 2.0, "C003", "Branco", false, Euthanasia.NO,
                         Gender.FEMALE, "Cacau", DogSize.SMALL, "Andrea", 11.0,
                         new DogBreed(3L, "003", "Shih Tzu", "Fofo e tranquilo", 10, 13,
                                 6.0, 8.0, 5.0, 7.0, false, "Pequeno"))
@@ -262,7 +254,7 @@ public class HealthRecordControllerTest {
     @Test
     public void given_existing_healthRecordId_when_deleteHealthRecord_then_returns_noContent() throws Exception{
         Long healthRecordId = 1L;
-        HealthRecord existingRecord = new HealthRecord(healthRecordId, LocalDate.of(2025, 2, 20),
+        HealthRecord existingRecord = new HealthRecord(healthRecordId,
                 4.0,"C357","Preto", false, Euthanasia.NO, Gender.MALE, "Nutella", DogSize.MEDIUM, "Clovis", 12.0,
                 new DogBreed(1L, "001", "Labrador", "Companheiro", 10, 12,
                         25.0, 30.0, 22.0, 28.0, false, "Médio"));
@@ -288,7 +280,7 @@ public class HealthRecordControllerTest {
     @Test
     public void given_existing_heathRecordId_when_getHealthRecordById_then_returns_record() throws Exception{
         Long healthRecordId = 1L;
-        HealthRecord existingRecord = new HealthRecord(healthRecordId, LocalDate.of(2025, 2, 20),
+        HealthRecord existingRecord = new HealthRecord(healthRecordId,
                 4.0,"C357","Preto", false, Euthanasia.NO, Gender.MALE, "Nutella", DogSize.MEDIUM, "Clovis", 12.0,
                 new DogBreed(1L, "001", "Labrador", "Companheiro", 10, 12,
                         25.0, 30.0, 22.0, 28.0, false, "Médio"));

--- a/src/test/java/com/project/vetdata/controller/HospitalAdmissionControllerIT.java
+++ b/src/test/java/com/project/vetdata/controller/HospitalAdmissionControllerIT.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.*;
-import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -96,7 +96,7 @@ public class HospitalAdmissionControllerIT {
                 29D, false, "Grande");
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
-        HealthRecord healthRecord = new HealthRecord(null, LocalDate.of(2025, 1, 16), 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
+        HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
                 "Torresmo", DogSize.LARGE, "Beatriz", 20.0, savedBreed);
         HealthRecord savedHealthRecord = healthRecordRepository.save(healthRecord);
 
@@ -178,7 +178,7 @@ public class HospitalAdmissionControllerIT {
                 29D, false, "Grande");
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
-        HealthRecord healthRecord = new HealthRecord(null, LocalDate.of(2025, 1, 16), 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
+        HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
                 "Torresmo", DogSize.LARGE, "Beatriz", 20.0, savedBreed);
         HealthRecord savedHealthRecord = healthRecordRepository.save(healthRecord);
 
@@ -247,7 +247,7 @@ public class HospitalAdmissionControllerIT {
                 29D, false, "Grande");
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
-        HealthRecord healthRecord = new HealthRecord(null, LocalDate.of(2025, 1, 16), 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
+        HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
                 "Torresmo", DogSize.LARGE, "Beatriz", 20.0, savedBreed);
         HealthRecord savedHealthRecord = healthRecordRepository.save(healthRecord);
 
@@ -288,5 +288,78 @@ public class HospitalAdmissionControllerIT {
                 .put("/hospital-admission/{id}")
                 .then()
                 .statusCode(400);
+    }
+
+    @Test
+    public void given_hospitalAdmissionsInDatabase_when_getAllHospitalAdmissions_then_returnsPagedList() {
+        DogBreed dogBreed = new DogBreed(null, "1", "Pug", "Amigável", 10, 12, 30D, 34D, 25D,
+                29D, false, "Grande");
+        DogBreed savedBreed = dogBreedRepository.save(dogBreed);
+
+        HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
+                "Torresmo", DogSize.LARGE, "Beatriz", 20.0, savedBreed);
+        HealthRecord savedHealthRecord = healthRecordRepository.save(healthRecord);
+
+        HealthRecord healthRecord2 = new HealthRecord(null, 3.5, "P02", "Branco", true, Euthanasia.YES, Gender.FEMALE,
+                "Cacau", DogSize.MEDIUM, "João", 18.0, savedBreed);
+        HealthRecord savedHealthRecord2 = healthRecordRepository.save(healthRecord2);
+
+        Diagnostic diagnostic = new Diagnostic("Fratura", "teste");
+        Diagnostic savedDiagnostic = diagnosticRepository.save(diagnostic);
+
+        PostOperative postOperative = new PostOperative("teste");
+        PostOperative savedPostOperative = postOperativeRepository.save(postOperative);
+
+        HospitalAdmission admission = new HospitalAdmission();
+        admission.setDate(LocalDate.of(2025, 7, 16));
+        admission.setReasonHospitalization("Tratamento");
+        admission.setDateMedicalDischarge(LocalDate.of(2025, 5, 10));
+        admission.setDateReturns(LocalDate.of(2025, 6, 16));
+        admission.setMedicalEvolution("Recuperando");
+        admission.setTreatmentNextSteps("Retorno");
+        admission.setHealthRecord(savedHealthRecord);
+        admission.setDiagnostics(Set.of(savedDiagnostic));
+        admission.setPostOperatives(Set.of(savedPostOperative));
+
+        HospitalAdmission savedAdmission = hospitalAdmissionRepository.save(admission);
+
+        HospitalAdmission admission2 = new HospitalAdmission();
+        admission2.setDate(LocalDate.of(2025, 8, 10));
+        admission2.setReasonHospitalization("Cirurgia");
+        admission2.setDateMedicalDischarge(LocalDate.of(2025, 6, 5));
+        admission2.setDateReturns(LocalDate.of(2025, 7, 12));
+        admission2.setMedicalEvolution("Recuperação");
+        admission2.setTreatmentNextSteps("Fisioterapia");
+        admission2.setHealthRecord(savedHealthRecord2);
+        admission2.setDiagnostics(Set.of(savedDiagnostic));
+        admission2.setPostOperatives(Set.of(savedPostOperative));
+
+        HospitalAdmission savedAdmission2 = hospitalAdmissionRepository.save(admission2);
+
+        when()
+                .get("/hospital-admission?page=0&qtdRecordsPage=2&sortBy=date")
+                .then()
+                .statusCode(200)
+                .body("[0].reasonHospitalization", equalTo("Tratamento"))
+                .body("[0].medicalEvolution", equalTo("Recuperando"))
+                .body("[0].date", equalTo("2025-07-16"))
+                .body("[0].dateMedicalDischarge", equalTo("2025-05-10"))
+                .body("[0].dateReturns", equalTo("2025-06-16"))
+
+                .body("[1].reasonHospitalization", equalTo("Cirurgia"))
+                .body("[1].medicalEvolution", equalTo("Recuperação"))
+                .body("[1].date", equalTo("2025-08-10"))
+                .body("[1].dateMedicalDischarge", equalTo("2025-06-05"))
+                .body("[1].dateReturns", equalTo("2025-07-12"));
+    }
+
+    @Test
+    public void given_no_hospitalAdmission_in_database_when_get_all_hospitalAdmission_then_returns_noContent() {
+        hospitalAdmissionRepository.deleteAll();
+
+        when()
+                .get("/health-records")
+                .then()
+                .statusCode(204);
     }
 }

--- a/src/test/java/com/project/vetdata/service/HealthRecordServiceImplIT.java
+++ b/src/test/java/com/project/vetdata/service/HealthRecordServiceImplIT.java
@@ -130,7 +130,6 @@ public class HealthRecordServiceImplIT {
         updateDTO.setPatient("Nutella");
         updateDTO.setTutor("Aline");
         updateDTO.setWeight(27.3);
-        updateDTO.setAdmission(LocalDate.of(2025, 4, 10));
         updateDTO.setBreedId(breed.getId());
         updateDTO.setEuthanasia(Euthanasia.NO);
         updateDTO.setGender(Gender.FEMALE);
@@ -142,7 +141,6 @@ public class HealthRecordServiceImplIT {
         assertEquals("Nutella", updated.getPatient());
         assertEquals("Aline", updated.getTutor());
         assertEquals(27.3, updated.getWeight());
-        assertEquals(LocalDate.of(2025, 4, 10), updated.getAdmission());
     }
 
     @Test
@@ -153,7 +151,6 @@ public class HealthRecordServiceImplIT {
         updateDTO.setPatient("Nutella");
         updateDTO.setTutor("Aline");
         updateDTO.setWeight(27.3);
-        updateDTO.setAdmission(LocalDate.of(2025, 4, 10));
         updateDTO.setBreedId(1L);
         updateDTO.setEuthanasia(Euthanasia.NO);
         updateDTO.setGender(Gender.FEMALE);
@@ -287,7 +284,6 @@ public class HealthRecordServiceImplIT {
 
     private HealthRecordCreateDTO getFakeHealthRecordDTO(Long breedId) {
         HealthRecordCreateDTO dto = new HealthRecordCreateDTO();
-        dto.setAdmission(LocalDate.of(2025, 8, 1));
         dto.setAge(5.0);
         dto.setCodPatient("C125");
         dto.setColor("Branco");
@@ -304,7 +300,6 @@ public class HealthRecordServiceImplIT {
 
     private HealthRecordCreateDTO getFakeHealthRecordDTO2(Long breedId) {
         HealthRecordCreateDTO dto = new HealthRecordCreateDTO();
-        dto.setAdmission(LocalDate.of(2025, 4, 8));
         dto.setAge(5.0);
         dto.setCodPatient("C123");
         dto.setColor("Branco");
@@ -324,7 +319,6 @@ public class HealthRecordServiceImplIT {
         dto.setPatient(null);
         dto.setAge(4.00);
         dto.setCodPatient("C123");
-        dto.setAdmission(LocalDate.of(2025, 4, 8));
         dto.setBreedId(1L);
         dto.setTutor("Beatriz");
         dto.setColor("Branco");

--- a/src/test/java/com/project/vetdata/service/HealthRecordServiceImplTest.java
+++ b/src/test/java/com/project/vetdata/service/HealthRecordServiceImplTest.java
@@ -226,7 +226,6 @@ public class HealthRecordServiceImplTest {
         dto.setGender(Gender.MALE);
         dto.setDeath(null);
         dto.setEuthanasia(Euthanasia.NO);
-        dto.setAdmission(LocalDate.of(2025,1,1));
 
         return dto;
     }
@@ -250,7 +249,6 @@ public class HealthRecordServiceImplTest {
         record.setGender(Gender.MALE);
         record.setDeath(null);
         record.setEuthanasia(Euthanasia.NO);
-        record.setAdmission(LocalDate.of(2025, 1, 1));
 
         return record;
     }
@@ -268,7 +266,6 @@ public class HealthRecordServiceImplTest {
         dto.setGender(Gender.FEMALE);
         dto.setDeath(false);
         dto.setEuthanasia(Euthanasia.NO);
-        dto.setAdmission(LocalDate.of(2025, 2, 1));
 
         return dto;
     }

--- a/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplIT.java
+++ b/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplIT.java
@@ -14,6 +14,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
@@ -24,6 +27,7 @@ import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -211,6 +215,51 @@ public class HospitalAdmissionServiceImplIT {
         assertEquals("Internação com ID " + invalidId + " não encontrada", exception.getMessage());
     }
 
+    @Test
+    public void given_existing_hospitalAdmissions_when_get_all_hospitalAdmission_then_returns_page_results() {
+        DogBreed breed = dogBreedRepository.save(createFakeBreed());
+        HealthRecord healthRecord = healthRecordRepository.save(createFakeHealthRecord(breed));
+        PostOperative postOperative = postOperativeRepository.save(createFakePostOperative());
+        Diagnostic diagnostic = diagnosticRepository.save(createFakeDiagnostic());
+
+        HospitalAdmissionCreateDTO dto1 = getFakeHospitalAdmissionDTO(
+                healthRecord.getId(),
+                List.of(postOperative.getId()),
+                List.of(diagnostic.getId())
+        );
+
+        HospitalAdmissionCreateDTO dto2 = getFakeHospitalAdmissionDTO2(
+                healthRecord.getId(),
+                List.of(postOperative.getId()),
+                List.of(diagnostic.getId())
+        );
+
+        hospitalAdmissionService.createHospitalAdmission(dto1);
+        hospitalAdmissionService.createHospitalAdmission(dto2);
+
+        List<HospitalAdmissionResponseDTO> result = hospitalAdmissionService.findAll();
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertEquals(2, result.size());
+
+        List<String> reasons = result.stream()
+                .map(HospitalAdmissionResponseDTO::getReasonHospitalization)
+                .collect(Collectors.toList());
+
+        assertTrue(reasons.contains("Infecção grave"));
+        assertTrue(reasons.contains("Teste"));
+    }
+
+    @Test
+    public void given_no_hospitalAdmission_in_database_when_get_all_hospitalAdmission_then_returns_empty_page() {
+        List<HospitalAdmissionResponseDTO> result = hospitalAdmissionService.findAll();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        assertEquals(0, result.size());
+    }
+
     private DogBreed createFakeBreed() {
         DogBreed breed = new DogBreed();
         breed.setName("Pug");
@@ -241,7 +290,6 @@ public class HospitalAdmissionServiceImplIT {
 
     private HealthRecord createFakeHealthRecord(DogBreed breed) {
         HealthRecord record = new HealthRecord();
-        record.setAdmission(LocalDate.of(2025, 8, 1));
         record.setAge(5.0);
         record.setCodPatient("C125");
         record.setColor("Branco");
@@ -264,6 +312,20 @@ public class HospitalAdmissionServiceImplIT {
         dto.setDateReturns(LocalDate.of(2025, 5, 1));
         dto.setMedicalEvolution("Teste");
         dto.setTreatmentNextSteps("Repouso e medicação");
+        dto.setHealthRecordId(healthRecordId);
+        dto.setPostOperativeIds(new HashSet<>(postOperativeIds));
+        dto.setDiagnosticIds(new HashSet<>(diagnosticIds));
+        return dto;
+    }
+
+    private HospitalAdmissionCreateDTO getFakeHospitalAdmissionDTO2 (Long healthRecordId, List<Long> postOperativeIds, List<Long> diagnosticIds) {
+        HospitalAdmissionCreateDTO dto = new HospitalAdmissionCreateDTO();
+        dto.setDate(LocalDate.of(2025, 4, 10));
+        dto.setReasonHospitalization("Teste");
+        dto.setDateMedicalDischarge(LocalDate.of(2025, 4, 20));
+        dto.setDateReturns(LocalDate.of(2025, 5, 1));
+        dto.setMedicalEvolution("Teste");
+        dto.setTreatmentNextSteps("Teste");
         dto.setHealthRecordId(healthRecordId);
         dto.setPostOperativeIds(new HashSet<>(postOperativeIds));
         dto.setDiagnosticIds(new HashSet<>(diagnosticIds));

--- a/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplTest.java
+++ b/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplTest.java
@@ -17,6 +17,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -196,6 +200,31 @@ public class HospitalAdmissionServiceImplTest {
         assertEquals("Pós Operatório não foi encontrado", exception.getMessage());
     }
 
+    @Test
+    public void given_existing_hospitalAdmission_when_getAll_then_returns_paginated_list() {
+        HospitalAdmission admission = getFakeHospitalAdmission();
+        List<HospitalAdmission> admissions = List.of(admission);
+
+        when(hospitalAdmissionRepository.findAll()).thenReturn(admissions);
+
+        List<HospitalAdmissionResponseDTO> result = hospitalAdmissionService.findAll();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(admission.getReasonHospitalization(), result.get(0).getReasonHospitalization());
+
+    }
+
+    @Test
+    public void given_no_hospitalAdmission_when_getAll_then_returns_empty_page() {
+        when(hospitalAdmissionRepository.findAll()).thenReturn(List.of());
+
+        List<HospitalAdmissionResponseDTO> result = hospitalAdmissionService.findAll();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
     private HospitalAdmissionCreateDTO getFakeHospitalAdmissionDTO() {
         HospitalAdmissionCreateDTO dto = new HospitalAdmissionCreateDTO();
         dto.setDate(LocalDate.of(2025, 4, 24));
@@ -233,8 +262,6 @@ public class HospitalAdmissionServiceImplTest {
         record.setGender(Gender.MALE);
         record.setDeath(null);
         record.setEuthanasia(Euthanasia.NO);
-        record.setAdmission(LocalDate.of(2025, 1, 1));
-
         return record;
     }
 


### PR DESCRIPTION
# Get All Hospital Admission

## Type
- [ ] Hotfix
- [x] New feature
- [ ] Refactor / Improvements

## Context
- Implementado o serviço de listagem de internação.
- Criado o endpoint GET /hospital-admission para buscar internações cadastradas.
- Adicionado o mapeamento e validações utilizando DTO.
- Validação de dados de entrada para garantir consistência.
- Retirado o campo admission da entidade  Health Record.

### Coverage Tests
![2](https://github.com/user-attachments/assets/1bfd7425-22cc-4f28-b5a2-ac6212205e6b)


### Checklist
- [x] Implementar a funcionalidade de listagem de internação.
- [x] Retirar o campo admission da entidade  Health Record.
- [x] Criar documentação no Swagger.
- [x] Criar testes automatizados.