### PR TITLE
Implement delete functionality for hospital admission

### DIFF
--- a/src/main/java/com/project/vetdata/controller/HospitalAdmissionController.java
+++ b/src/main/java/com/project/vetdata/controller/HospitalAdmissionController.java
@@ -71,4 +71,21 @@ public class HospitalAdmissionController {
         List<HospitalAdmissionResponseDTO> admissions = hospitalAdmissionService.findAll();
         return  ResponseEntity.ok(admissions);
     }
+
+    @Operation(summary = "Remover internação por ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Internação removida!"),
+            @ApiResponse(responseCode = "404", description = "Intenação não encontrada!", content = @Content)
+    })
+    @DeleteMapping("{id}")
+    public ResponseEntity<Void> deleteHospitalAdmission(@PathVariable Long id) {
+        return hospitalAdmissionService.getHospitalAdmissionById(id)
+                .map(this::handleDelete)
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    private ResponseEntity<Void> handleDelete(HospitalAdmission admission) {
+        hospitalAdmissionService.deleteHospitalAdmission(admission.getId());
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/src/main/java/com/project/vetdata/service/HospitalAdmissionService.java
+++ b/src/main/java/com/project/vetdata/service/HospitalAdmissionService.java
@@ -9,9 +9,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface HospitalAdmissionService {
     HospitalAdmissionResponseDTO createHospitalAdmission(HospitalAdmissionCreateDTO dto);
     HospitalAdmissionResponseDTO updateHospitalAdmission(Long id, HospitalAdmissionUpdateDTO dto);
     List<HospitalAdmissionResponseDTO> findAll();
+    void deleteHospitalAdmission(Long id);
+    Optional<HospitalAdmission> getHospitalAdmissionById(Long id);
 }

--- a/src/main/java/com/project/vetdata/service/HospitalAdmissionServiceImpl.java
+++ b/src/main/java/com/project/vetdata/service/HospitalAdmissionServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -156,5 +157,15 @@ public class HospitalAdmissionServiceImpl implements HospitalAdmissionService {
         return admissions.stream()
                 .map(this::mapToResponse)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteHospitalAdmission(Long id) {
+        hospitalAdmissionRepository.deleteById(id);
+    }
+
+    @Override
+    public Optional<HospitalAdmission> getHospitalAdmissionById(Long id) {
+        return hospitalAdmissionRepository.findById(id);
     }
 }

--- a/src/test/java/com/project/vetdata/controller/HospitalAdmissionControllerIT.java
+++ b/src/test/java/com/project/vetdata/controller/HospitalAdmissionControllerIT.java
@@ -362,4 +362,85 @@ public class HospitalAdmissionControllerIT {
                 .then()
                 .statusCode(204);
     }
+
+    @Test
+    public void given_existing_hospitalAdmissionId_when_deleteHospitalAdmission_then_returnsNoContent() {
+        DogBreed dogBreed = new DogBreed(null, "1", "Pug", "Amigável", 10, 12, 30D, 34D, 25D,
+                29D, false, "Grande");
+        DogBreed savedBreed = dogBreedRepository.save(dogBreed);
+
+        HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
+                "Torresmo", DogSize.LARGE, "Beatriz", 20.0, savedBreed);
+        HealthRecord savedHealthRecord = healthRecordRepository.save(healthRecord);
+
+        Diagnostic diagnostic = new Diagnostic("Fratura", "teste");
+        Diagnostic savedDiagnostic = diagnosticRepository.save(diagnostic);
+
+        PostOperative postOperative = new PostOperative("teste");
+        PostOperative savedPostOperative = postOperativeRepository.save(postOperative);
+
+        HospitalAdmission admission = new HospitalAdmission();
+        admission.setDate(LocalDate.of(2025, 7, 16));
+        admission.setReasonHospitalization("Tratamento");
+        admission.setDateMedicalDischarge(LocalDate.of(2025, 5, 10));
+        admission.setDateReturns(LocalDate.of(2025, 6, 16));
+        admission.setMedicalEvolution("Recuperando");
+        admission.setTreatmentNextSteps("Retorno");
+        admission.setHealthRecord(savedHealthRecord);
+        admission.setDiagnostics(Set.of(savedDiagnostic));
+        admission.setPostOperatives(Set.of(savedPostOperative));
+        HospitalAdmission savedAdmission = hospitalAdmissionRepository.save(admission);
+
+        given()
+                .pathParam("id", savedAdmission.getId())
+                .when()
+                .delete("/hospital-admission/{id}")
+                .then()
+                .statusCode(204);
+
+        Optional<HospitalAdmission> deleted = hospitalAdmissionRepository.findById(savedAdmission.getId());
+        assertTrue(deleted.isEmpty(), "A internação deveria ter sido deletada do banco");
+    }
+
+    @Test
+    public void given_non_existing_hospitalAdmissionId_when_deleteHospitalAdmission_then_returns_notFound() {
+        DogBreed dogBreed = new DogBreed(null, "1", "Pug", "Amigável", 10, 12, 30D, 34D, 25D,
+                29D, false, "Grande");
+        DogBreed savedBreed = dogBreedRepository.save(dogBreed);
+
+        HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
+                "Torresmo", DogSize.LARGE, "Beatriz", 20.0, savedBreed);
+        HealthRecord savedHealthRecord = healthRecordRepository.save(healthRecord);
+
+        Diagnostic diagnostic = new Diagnostic("Fratura", "teste");
+        Diagnostic savedDiagnostic = diagnosticRepository.save(diagnostic);
+
+        PostOperative postOperative = new PostOperative("teste");
+        PostOperative savedPostOperative = postOperativeRepository.save(postOperative);
+
+        HospitalAdmission admission = new HospitalAdmission();
+        admission.setDate(LocalDate.of(2025, 7, 16));
+        admission.setReasonHospitalization("Tratamento");
+        admission.setDateMedicalDischarge(LocalDate.of(2025, 5, 10));
+        admission.setDateReturns(LocalDate.of(2025, 6, 16));
+        admission.setMedicalEvolution("Recuperando");
+        admission.setTreatmentNextSteps("Retorno");
+        admission.setHealthRecord(savedHealthRecord);
+        admission.setDiagnostics(Set.of(savedDiagnostic));
+        admission.setPostOperatives(Set.of(savedPostOperative));
+        HospitalAdmission savedAdmission = hospitalAdmissionRepository.save(admission);
+
+        given()
+                .pathParam("id", 99L)
+                .when()
+                .delete("/hospital-admission/{id}")
+                .then()
+                .statusCode(404);
+
+        HospitalAdmission existingAdmission = hospitalAdmissionRepository.findById(admission.getId()).orElse(null);
+        assertNotNull(existingAdmission, "A internação deveria existir no bancko de dados.");
+        assertEquals("Tratamento", existingAdmission.getReasonHospitalization());
+        assertEquals("Recuperando", existingAdmission.getMedicalEvolution());
+        assertEquals("Retorno", existingAdmission.getTreatmentNextSteps());
+    }
 }

--- a/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplIT.java
+++ b/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplIT.java
@@ -26,6 +26,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -258,6 +259,37 @@ public class HospitalAdmissionServiceImplIT {
         assertNotNull(result);
         assertTrue(result.isEmpty());
         assertEquals(0, result.size());
+    }
+
+    @Test
+    public void given_valid_is_when_deleteHospitalAdmission_then_record_is_deleted() {
+        DogBreed breed = dogBreedRepository.save(createFakeBreed());
+        HealthRecord healthRecord = healthRecordRepository.save(createFakeHealthRecord(breed));
+        PostOperative postOperative = postOperativeRepository.save(createFakePostOperative());
+        Diagnostic diagnostic = diagnosticRepository.save(createFakeDiagnostic());
+
+        HospitalAdmissionCreateDTO dto = getFakeHospitalAdmissionDTO(healthRecord.getId(), List.of(postOperative.getId()), List.of(diagnostic.getId()));
+
+        HospitalAdmissionResponseDTO admission = hospitalAdmissionService.createHospitalAdmission(dto);
+
+        assertNotNull(admission.getId(), "Confere se a internação foi salva!");
+
+        Long id = admission.getId();
+        hospitalAdmissionService.deleteHospitalAdmission(id);
+
+        Optional<HospitalAdmission> deleted = hospitalAdmissionRepository.findById(id);
+        assertFalse(deleted.isPresent(), "A internação deve ter sido deletada!");
+    }
+
+    @Test
+    public void given_invalid_id_when_deleteHospitalAdmission_then_no_exception_throws() {
+        Long invalidId = 99L;
+
+        try {
+            hospitalAdmissionService.deleteHospitalAdmission(invalidId);
+        } catch (Exception ex) {
+            fail("Não deve ter exceções");
+        }
     }
 
     private DogBreed createFakeBreed() {

--- a/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplTest.java
+++ b/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplTest.java
@@ -225,6 +225,24 @@ public class HospitalAdmissionServiceImplTest {
         assertTrue(result.isEmpty());
     }
 
+    @Test
+    public void given_valid_is_when_deleteHospitalAdmission_is_called_then_user_is_deleted() {
+        Long hospitalAdmissionId = 1L;
+
+        hospitalAdmissionService.deleteHospitalAdmission(hospitalAdmissionId);
+
+        verify(hospitalAdmissionRepository, times(1)).deleteById(hospitalAdmissionId);
+    }
+
+    @Test
+    public void given_invalid_id_when_deleteHospitalAdmission_the_no_exception_is_thrown_and_repository_is_called() {
+        Long invalidHospitalAdmissionId = 999L;
+
+        hospitalAdmissionService.deleteHospitalAdmission(invalidHospitalAdmissionId);
+
+        verify(hospitalAdmissionRepository, times(1)).deleteById(invalidHospitalAdmissionId);
+    }
+
     private HospitalAdmissionCreateDTO getFakeHospitalAdmissionDTO() {
         HospitalAdmissionCreateDTO dto = new HospitalAdmissionCreateDTO();
         dto.setDate(LocalDate.of(2025, 4, 24));


### PR DESCRIPTION
# Delete Hospital Admission

## Type
- [ ] Hotfix
- [x] New feature
- [ ] Refactor / Improvements

## Context
- Implementado o serviço de exclusão de internação.
- Criado o endpoint DELETE /hospital-admission/{id} para remoção de internações cadastradas.
- Adicionada validação para garantir que apenas internações existentes sejam deletadas.

### Coverage Tests
![2](https://github.com/user-attachments/assets/bb08423a-ee76-4100-8cc4-76940df3ce8a)


### Checklist
- [x] Implementar a funcionalidade de exclusão de internação.
- [x] Criar documentação no Swagger.
- [x] Criar testes automatizados.