### PR TITLE
Implement authentication API

### DIFF
--- a/src/main/java/com/project/vetdata/controller/AuthenticationController.java
+++ b/src/main/java/com/project/vetdata/controller/AuthenticationController.java
@@ -1,0 +1,40 @@
+package com.project.vetdata.controller;
+
+import com.project.vetdata.dto.AuthenticationRequestDTO;
+import com.project.vetdata.dto.AuthenticationResponseDTO;
+import com.project.vetdata.service.AuthenticationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/authentications")
+public class AuthenticationController {
+
+    private final AuthenticationService authenticationService;
+
+    public AuthenticationController(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
+    }
+
+    @Operation(summary = "Autenticar usuário com email e senha")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Usuário autenticado com sucesso!",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AuthenticationResponseDTO.class))),
+            @ApiResponse(responseCode = "400", description = "Requisição inválida (campos obrigatórios não preenchidos)", content = @Content)
+    })
+    @PostMapping
+    public ResponseEntity<AuthenticationResponseDTO> authenticate(@RequestBody @Valid AuthenticationRequestDTO dto) {
+        AuthenticationResponseDTO response = authenticationService.authenticate(dto);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/project/vetdata/dto/AuthenticationRequestDTO.java
+++ b/src/main/java/com/project/vetdata/dto/AuthenticationRequestDTO.java
@@ -1,0 +1,5 @@
+package com.project.vetdata.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthenticationRequestDTO(@NotBlank String email, @NotBlank String password) {}

--- a/src/main/java/com/project/vetdata/dto/AuthenticationResponseDTO.java
+++ b/src/main/java/com/project/vetdata/dto/AuthenticationResponseDTO.java
@@ -1,0 +1,5 @@
+package com.project.vetdata.dto;
+
+import com.project.vetdata.enums.AuthenticationStatus;
+
+public record AuthenticationResponseDTO(AuthenticationStatus status, String name) {}

--- a/src/main/java/com/project/vetdata/enums/AuthenticationStatus.java
+++ b/src/main/java/com/project/vetdata/enums/AuthenticationStatus.java
@@ -1,0 +1,8 @@
+package com.project.vetdata.enums;
+
+public enum AuthenticationStatus {
+    AUTHORIZED,
+    NOT_AUTHORIZED,
+    INACTIVE,
+    PASSWORD_EXPIRED
+}

--- a/src/main/java/com/project/vetdata/service/AuthenticationService.java
+++ b/src/main/java/com/project/vetdata/service/AuthenticationService.java
@@ -1,0 +1,8 @@
+package com.project.vetdata.service;
+
+import com.project.vetdata.dto.AuthenticationRequestDTO;
+import com.project.vetdata.dto.AuthenticationResponseDTO;
+
+public interface AuthenticationService {
+    AuthenticationResponseDTO authenticate(AuthenticationRequestDTO requestDTO);
+}

--- a/src/main/java/com/project/vetdata/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/project/vetdata/service/AuthenticationServiceImpl.java
@@ -1,0 +1,34 @@
+package com.project.vetdata.service;
+
+import com.password4j.Password;
+import com.project.vetdata.dto.AuthenticationRequestDTO;
+import com.project.vetdata.dto.AuthenticationResponseDTO;
+import com.project.vetdata.enums.AuthenticationStatus;
+import com.project.vetdata.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthenticationServiceImpl implements AuthenticationService {
+
+    private final UserRepository userRepository;
+
+    public AuthenticationServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public AuthenticationResponseDTO authenticate(AuthenticationRequestDTO dto) {
+        return userRepository.findByEmail(dto.email())
+                .map(user -> {
+                    boolean passwordOk = Password.check(dto.password(), user.getPassword()).withBcrypt();
+
+                    if (passwordOk) {
+                        return new AuthenticationResponseDTO(AuthenticationStatus.AUTHORIZED, user.getName());
+                    } else {
+                        return new AuthenticationResponseDTO(AuthenticationStatus.NOT_AUTHORIZED, null);
+                    }
+                })
+                .orElseGet(() -> new AuthenticationResponseDTO(AuthenticationStatus.NOT_AUTHORIZED, null));
+    }
+
+}

--- a/src/test/java/com/project/vetdata/controller/AuthenticationRestControllerIT.java
+++ b/src/test/java/com/project/vetdata/controller/AuthenticationRestControllerIT.java
@@ -1,0 +1,149 @@
+package com.project.vetdata.controller;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.password4j.Password;
+import com.project.vetdata.dto.AuthenticationRequestDTO;
+import com.project.vetdata.model.User;
+import com.project.vetdata.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+
+import static org.hamcrest.Matchers.*;
+
+import java.time.LocalDateTime;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+public class AuthenticationRestControllerIT {
+
+    @LocalServerPort
+    private Integer port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private static final int WIREMOCK_PORT = 8082;
+
+    private static WireMockServer wireMockServer;
+
+    @Container
+    private static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.26");
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        userRepository.deleteAll();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        mysqlContainer.start();
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().port(WIREMOCK_PORT));
+        wireMockServer.start();
+        WireMock.configureFor("localhost", WIREMOCK_PORT);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        mysqlContainer.stop();
+        wireMockServer.stop();
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+
+    @Test
+    public void given_valid_credentials_when_login_then_returns_authorized() {
+        User user = new User();
+        user.setName("Aline");
+        user.setEmail("aline@vetdata.com");
+        user.setPassword(Password.hash("Senha%1").withBcrypt().getResult());
+        user.setCreatedDate(LocalDateTime.now());
+        user.setPasswordLastUpdatedDate(LocalDateTime.now());
+        userRepository.save(user);
+
+        AuthenticationRequestDTO request = new AuthenticationRequestDTO("aline@vetdata.com", "Senha%1");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/authentications")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo("AUTHORIZED"))
+                .body("name", equalTo("Aline"));
+    }
+
+    @Test
+    public void given_invalid_email_when_login_then_returns_not_authorized() {
+        AuthenticationRequestDTO request = new AuthenticationRequestDTO("cleyton@vetdata.com", "Senha%1");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/authentications")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo("NOT_AUTHORIZED"))
+                .body("name", nullValue());
+    }
+
+    @Test
+    public void given_invalid_password_when_login_then_returns_not_authorized() {
+        User user = new User();
+        user.setName("Aline");
+        user.setEmail("aline@vetdata.com");
+        user.setPassword(Password.hash("Senha%1").withBcrypt().getResult());
+        user.setCreatedDate(LocalDateTime.now());
+        user.setPasswordLastUpdatedDate(LocalDateTime.now());
+        userRepository.save(user);
+
+        AuthenticationRequestDTO request = new AuthenticationRequestDTO("aline@vetdata.com", "Senha%2");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/authentications")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo("NOT_AUTHORIZED"))
+                .body("name", nullValue());
+    }
+
+    @Test
+    public void given_blank_fields_when_login_then_returns_400() {
+        AuthenticationRequestDTO request = new AuthenticationRequestDTO("", "");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/authentications")
+                .then()
+                .statusCode(400);
+    }
+}

--- a/src/test/java/com/project/vetdata/service/AuthenticationServiceImplIT.java
+++ b/src/test/java/com/project/vetdata/service/AuthenticationServiceImplIT.java
@@ -1,0 +1,116 @@
+package com.project.vetdata.service;
+
+import com.password4j.Password;
+import com.project.vetdata.dto.AuthenticationRequestDTO;
+import com.project.vetdata.dto.AuthenticationResponseDTO;
+import com.project.vetdata.enums.AuthenticationStatus;
+import com.project.vetdata.model.User;
+import com.project.vetdata.repository.UserRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+public class AuthenticationServiceImplIT {
+
+    @Container
+    private static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.26");
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AuthenticationServiceImpl authenticationService;
+
+    @BeforeAll
+    static void beforeAll() {
+        mysqlContainer.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        mysqlContainer.stop();
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+
+    @BeforeEach
+    void setup() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void connectionEstablished() {
+        assertThat(mysqlContainer.isCreated()).isTrue();
+        assertThat(mysqlContainer.isRunning()).isTrue();
+    }
+
+    @Test
+    public void given_valid_credentials_when_authenticate_then_return_authorized() {
+        User user = new User();
+        user.setName("Beatriz");
+        user.setEmail("beatriz@vetdata.com");
+        user.setPassword((Password.hash("Senha%1").withBcrypt().getResult()));
+        user.setCreatedDate(LocalDateTime.now());
+        user.setPasswordLastUpdatedDate(LocalDateTime.now());
+        userRepository.save(user);
+
+        AuthenticationRequestDTO dto = new AuthenticationRequestDTO("beatriz@vetdata.com", "Senha%1");
+
+        AuthenticationResponseDTO response = authenticationService.authenticate(dto);
+
+        assertNotNull(response);
+        assertEquals(AuthenticationStatus.AUTHORIZED, response.status());
+        assertEquals("Beatriz", response.name());
+    }
+
+    @Test
+    public void given_invalid_password_when_authenticate_then_return_not_authorized() {
+        User user = new User();
+        user.setName("Cleyton");
+        user.setEmail("cleyton@vetdata.com");
+        user.setPassword((Password.hash("Senha%1").withBcrypt().getResult()));
+        user.setCreatedDate(LocalDateTime.now());
+        user.setPasswordLastUpdatedDate(LocalDateTime.now());
+        userRepository.save(user);
+
+        AuthenticationRequestDTO dto = new AuthenticationRequestDTO("cleyton@vetdata.com", "Senha%2");
+
+        AuthenticationResponseDTO response = authenticationService.authenticate(dto);
+
+        assertNotNull(response);
+        assertEquals(AuthenticationStatus.NOT_AUTHORIZED, response.status());
+        assertNull(response.name());
+    }
+
+    @Test
+    void given_nonexistent_email_when_authenticate_then_return_not_authorized() {
+        AuthenticationRequestDTO dto = new AuthenticationRequestDTO("cleyton@vetdata.com", "Senha%1");
+
+        AuthenticationResponseDTO response = authenticationService.authenticate(dto);
+
+        assertNotNull(response);
+        assertEquals(AuthenticationStatus.NOT_AUTHORIZED, response.status());
+        assertNull(response.name());
+    }
+}

--- a/src/test/java/com/project/vetdata/service/AuthenticationServiceImplTest.java
+++ b/src/test/java/com/project/vetdata/service/AuthenticationServiceImplTest.java
@@ -1,0 +1,94 @@
+package com.project.vetdata.service;
+
+import com.password4j.Password;
+import com.project.vetdata.dto.AuthenticationRequestDTO;
+import com.project.vetdata.dto.AuthenticationResponseDTO;
+import com.project.vetdata.enums.AuthenticationStatus;
+import com.project.vetdata.model.User;
+import com.project.vetdata.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthenticationServiceImplTest {
+
+    @InjectMocks
+    private AuthenticationServiceImpl authenticationService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    public void given_valid_credentials_when_authenticate_then_return_authorized() {
+        String email = "cleyton@vetdata.com";
+        String password = "Senha%1";
+        String hashedPassword = Password.hash(password).withBcrypt().getResult();
+
+        User user = new User();
+        user.setName("Cleyton");
+        user.setEmail(email);
+        user.setPassword(hashedPassword);
+        user.setCreatedDate(LocalDateTime.now());
+        user.setPasswordLastUpdatedDate(LocalDateTime.now());
+
+        AuthenticationRequestDTO dto = new AuthenticationRequestDTO(email, password);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        AuthenticationResponseDTO response = authenticationService.authenticate(dto);
+
+        assertNotNull(response);
+        assertEquals(AuthenticationStatus.AUTHORIZED, response.status());
+        assertEquals("Cleyton", response.name());
+    }
+
+    @Test
+    public void given_invalid_password_when_authenticate_then_return_not_authorized() {
+        String email = "cleyton@vetdata.com";
+        String password = "Senha%1";
+        String wrongPassword = "Senha%2";
+        String hashedPassWord = Password.hash(password).withBcrypt().getResult();
+
+        User user = new User();
+        user.setName("Cleyton");
+        user.setEmail(email);
+        user.setPassword(hashedPassWord);
+        user.setCreatedDate(LocalDateTime.now());
+        user.setPasswordLastUpdatedDate(LocalDateTime.now());
+
+        AuthenticationRequestDTO dto = new AuthenticationRequestDTO(email, wrongPassword);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        AuthenticationResponseDTO response = authenticationService.authenticate(dto);
+
+        assertNotNull(response);
+        assertEquals(AuthenticationStatus.NOT_AUTHORIZED, response.status());
+        assertNull(response.name());
+    }
+
+    @Test
+    public void given_none_existent_email_when_authenticate_then_return_not_authorized() {
+        String email = "beatriz@vetdata.com";
+        String password = "Senha%1";
+
+        AuthenticationRequestDTO dto = new AuthenticationRequestDTO(email, password);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        AuthenticationResponseDTO response = authenticationService.authenticate(dto);
+
+        assertNotNull(response);
+        assertEquals(AuthenticationStatus.NOT_AUTHORIZED, response.status());
+        assertNull(response.name());
+    }
+}


### PR DESCRIPTION
# Authentication API

## Type
- [ ] Hotfix
- [x] New feature
- [ ] Refactor / Improvements

## Context
- Implementada a autenticação de usuários através do endpoint POST /authentications.
- Adicionado o DTO AuthenticationRequestDTO contendo os campos de email e senha.
- Criado o AuthenticationResponseDTO com status de autenticação e nome do usuário.

### Coverage Tests
![2](https://github.com/user-attachments/assets/5cc21d07-e881-417a-8896-700204281791)


### Checklist
- [x] Autenticação com credenciais válidas retorna status AUTHORIZED e nome.
- [x] Autenticação com email inexistente retorna status NOT_AUTHORIZED.
- [x] Autenticação com senha incorreta retorna status NOT_AUTHORIZED.
- [x] Criar documentação no Swagger.
- [x] Criar testes automatizados.