### PR TITLE
Remove size field from DogBreed entity

### DIFF
--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -30,7 +30,6 @@ CREATE TABLE IF NOT EXISTS `dog_breeds` (
   `male_weight_max` double NOT NULL,
   `male_weight_min` double NOT NULL,
   `name` varchar(255) NOT NULL,
-  `size` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1421 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 

--- a/src/main/java/com/project/vetdata/controller/DogBreedRestController.java
+++ b/src/main/java/com/project/vetdata/controller/DogBreedRestController.java
@@ -93,8 +93,7 @@ public class DogBreedRestController {
                 dogBreed.getMaleWeightMax(),
                 dogBreed.getFemaleWeightMin(),
                 dogBreed.getFemaleWeightMax(),
-                dogBreed.getHypoallergenic(),
-                dogBreed.getSize()
+                dogBreed.getHypoallergenic()
         );
     }
 

--- a/src/main/java/com/project/vetdata/dto/DogBreedCreateDTO.java
+++ b/src/main/java/com/project/vetdata/dto/DogBreedCreateDTO.java
@@ -15,13 +15,12 @@ public class DogBreedCreateDTO {
     private Double femaleWeightMin;
     private Double femaleWeightMax;
     private Boolean hypoallergenic;
-    private String size;
 
     public  DogBreedCreateDTO() {
     }
 
     public DogBreedCreateDTO(String name, String description, Integer lifeExpectancyMin, Integer lifeExpectancyMax, Double maleWeightMin, Double maleWeightMax, Double femaleWeightMin,
-                             Double femaleWeightMax, Boolean hypoallergenic, String size) {
+                             Double femaleWeightMax, Boolean hypoallergenic) {
         this.name = name;
         this.description = description;
         this.lifeExpectancyMin = lifeExpectancyMin;
@@ -31,7 +30,6 @@ public class DogBreedCreateDTO {
         this.femaleWeightMin = femaleWeightMin;
         this.femaleWeightMax = femaleWeightMax;
         this.hypoallergenic = hypoallergenic;
-        this.size = size;
         }
 
     @NotBlank(message = "Campo Obrigatório")
@@ -84,11 +82,6 @@ public class DogBreedCreateDTO {
         return hypoallergenic;
     }
 
-    @NotBlank(message = "Campo Obrigatório")
-    public String getSize() {
-        return size;
-    }
-
     public void setName(String name) {
         this.name = name;
     }
@@ -122,10 +115,6 @@ public class DogBreedCreateDTO {
 
     public void setHypoallergenic(Boolean hypoallergenic) {
         this.hypoallergenic = hypoallergenic;
-    }
-
-    public void setSize(String size) {
-        this.size = size;
     }
 
 }

--- a/src/main/java/com/project/vetdata/dto/DogBreedDTO.java
+++ b/src/main/java/com/project/vetdata/dto/DogBreedDTO.java
@@ -12,12 +12,11 @@ public class DogBreedDTO {
     private Double femaleWeightMin;
     private Double femaleWeightMax;
     private Boolean hypoallergenic;
-    private String size;
 
     public DogBreedDTO(){}
 
     public DogBreedDTO(Long id ,String name, String description, Integer lifeExpectancyMin, Integer lifeExpectancyMax, Double maleWeightMin, Double maleWeightMax,
-                            Double femaleWeightMin, Double femaleWeightMax, Boolean hypoallergenic, String size) {
+                            Double femaleWeightMin, Double femaleWeightMax, Boolean hypoallergenic) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -28,7 +27,6 @@ public class DogBreedDTO {
         this.femaleWeightMin = femaleWeightMin;
         this.femaleWeightMax = femaleWeightMax;
         this.hypoallergenic = hypoallergenic;
-        this.size = size;
     }
 
     public Long getId() {
@@ -69,10 +67,6 @@ public class DogBreedDTO {
 
     public Boolean getHypoallergenic() {
         return hypoallergenic;
-    }
-
-    public String getSize() {
-        return size;
     }
 
     public void setName(String name) {

--- a/src/main/java/com/project/vetdata/dto/DogBreedUpdateDTO.java
+++ b/src/main/java/com/project/vetdata/dto/DogBreedUpdateDTO.java
@@ -14,9 +14,8 @@ public class DogBreedUpdateDTO {
     private Double femaleWeightMin;
     private Double femaleWeightMax;
     private Boolean hypoallergenic;
-    private String size;
 
-    public DogBreedUpdateDTO(String name, String description, Integer lifeExpectancyMin, Integer lifeExpectancyMax, Double maleWeightMin, Double maleWeightMax, Double femaleWeightMin, Double femaleWeightMax, Boolean hypoallergenic, String size) {
+    public DogBreedUpdateDTO(String name, String description, Integer lifeExpectancyMin, Integer lifeExpectancyMax, Double maleWeightMin, Double maleWeightMax, Double femaleWeightMin, Double femaleWeightMax, Boolean hypoallergenic) {
         this.name = name;
         this.description = description;
         this.lifeExpectancyMin = lifeExpectancyMin;
@@ -26,7 +25,6 @@ public class DogBreedUpdateDTO {
         this.femaleWeightMin = femaleWeightMin;
         this.femaleWeightMax = femaleWeightMax;
         this.hypoallergenic = hypoallergenic;
-        this.size = size;
     }
 
     @NotBlank(message = "Campo Obrigatório")
@@ -86,11 +84,6 @@ public class DogBreedUpdateDTO {
         return hypoallergenic;
     }
 
-    @NotBlank(message = "Campo Obrigatório")
-    public String getSize() {
-        return size;
-    }
-
     public void setDescription(String description) {
         this.description = description;
     }
@@ -123,7 +116,4 @@ public class DogBreedUpdateDTO {
         this.hypoallergenic = hypoallergenic;
     }
 
-    public void setSize(String size) {
-        this.size = size;
-    }
 }

--- a/src/main/java/com/project/vetdata/model/DogBreed.java
+++ b/src/main/java/com/project/vetdata/model/DogBreed.java
@@ -44,13 +44,12 @@ public class DogBreed {
 
     private Boolean hypoallergenic;
 
-    private String size;
 
     public DogBreed() {
     }
 
     public DogBreed(Long id, String idExternalApi ,String name, String description, Integer lifeExpectancyMin, Integer lifeExpectancyMax, Double maleWeightMin, Double maleWeightMax, Double femaleWeightMin,
-                    Double femaleWeightMax, Boolean hypoallergenic, String size) {
+                    Double femaleWeightMax, Boolean hypoallergenic) {
         this.id = id;
         this.idExternalApi = idExternalApi;
         this.name = name;
@@ -62,7 +61,6 @@ public class DogBreed {
         this.femaleWeightMin = femaleWeightMin;
         this.femaleWeightMax = femaleWeightMax;
         this.hypoallergenic = hypoallergenic;
-        this.size = size;
     }
 
     public Long getId() {
@@ -113,10 +111,6 @@ public class DogBreed {
         this.id = id;
     }
 
-    public String getSize() {
-        return size;
-    }
-
     public void setIdExternalApi(String idExternalApi) {
         this.idExternalApi = idExternalApi;
     }
@@ -157,9 +151,6 @@ public class DogBreed {
         this.hypoallergenic = hypoallergenic;
     }
 
-    public void setSize(String size) {
-        this.size = size;
-    }
 }
 
 

--- a/src/main/java/com/project/vetdata/service/DogBreedExternalService.java
+++ b/src/main/java/com/project/vetdata/service/DogBreedExternalService.java
@@ -66,7 +66,6 @@ public class DogBreedExternalService {
         breed.setFemaleWeightMin(dto.getAttributeDTO().getFemaleWeightDTO().getMin());
         breed.setFemaleWeightMax(dto.getAttributeDTO().getFemaleWeightDTO().getMax());
         breed.setHypoallergenic(dto.getAttributeDTO().getHypoallergenic());
-        breed.setSize(null);
         return breed;
     }
 
@@ -80,8 +79,7 @@ public class DogBreedExternalService {
                 dogBreed.getMaleWeightMax(),
                 dogBreed.getFemaleWeightMin(),
                 dogBreed.getFemaleWeightMax(),
-                dogBreed.getHypoallergenic(),
-                dogBreed.getSize()
+                dogBreed.getHypoallergenic()
         );
     }
 

--- a/src/main/java/com/project/vetdata/service/DogBreedServiceImpl.java
+++ b/src/main/java/com/project/vetdata/service/DogBreedServiceImpl.java
@@ -82,9 +82,6 @@ public class DogBreedServiceImpl implements DogBreedService {
             if (dogBreedUpdateDTO.getHypoallergenic() != null) {
                 existingBreed.setHypoallergenic(dogBreedUpdateDTO.getHypoallergenic());
             }
-            if (dogBreedUpdateDTO.getSize() != null) {
-                existingBreed.setSize(dogBreedUpdateDTO.getSize());
-            }
             return dogBreedRepository.save(existingBreed);
         }).orElseThrow(() -> new BreedNotFoundException("Raça não encontrada!" + id));
     }
@@ -105,7 +102,6 @@ public class DogBreedServiceImpl implements DogBreedService {
         breed.setFemaleWeightMin(dto.getFemaleWeightMin());
         breed.setFemaleWeightMax(dto.getFemaleWeightMax());
         breed.setHypoallergenic(dto.getHypoallergenic());
-        breed.setSize(dto.getSize());
         breed.setIdExternalApi(null);
         return breed;
     }

--- a/src/test/java/com/project/vetdata/controller/DogBreedRestControllerIT.java
+++ b/src/test/java/com/project/vetdata/controller/DogBreedRestControllerIT.java
@@ -98,7 +98,6 @@ public class DogBreedRestControllerIT {
         dogBreed.setFemaleWeightMin(11D);
         dogBreed.setFemaleWeightMax(15D);
         dogBreed.setHypoallergenic(true);
-        dogBreed.setSize("Pequeno");
         DogBreed save = dogBreedRepository.save(dogBreed);
         when()
                 .get("/breeds/{id}", 1L)
@@ -113,8 +112,7 @@ public class DogBreedRestControllerIT {
                 .body("maleWeightMax", equalTo(16.0F))
                 .body("femaleWeightMin", equalTo(11.0F))
                 .body("femaleWeightMax", equalTo(15.0F))
-                .body("hypoallergenic", equalTo(save.getHypoallergenic()))
-                .body("size", equalTo(save.getSize()));
+                .body("hypoallergenic", equalTo(save.getHypoallergenic()));
     }
 
     @Test
@@ -146,7 +144,6 @@ public class DogBreedRestControllerIT {
         dogBreed.setFemaleWeightMin(11D);
         dogBreed.setFemaleWeightMax(15D);
         dogBreed.setHypoallergenic(true);
-        dogBreed.setSize("Pequeno");
 
         DogBreed dogBreed2 = new DogBreed();
         dogBreed2.setId(12L);
@@ -159,7 +156,6 @@ public class DogBreedRestControllerIT {
         dogBreed2.setFemaleWeightMin(11D);
         dogBreed2.setFemaleWeightMax(15D);
         dogBreed2.setHypoallergenic(false);
-        dogBreed2.setSize("Médio");
 
         DogBreed save = dogBreedRepository.save(dogBreed);
         DogBreed save2 = dogBreedRepository.save(dogBreed2);
@@ -206,7 +202,6 @@ public class DogBreedRestControllerIT {
         dogBreed.setFemaleWeightMin(7.0D);
         dogBreed.setFemaleWeightMax(11.0D);
         dogBreed.setHypoallergenic(true);
-        dogBreed.setSize("Médio");
 
         DogBreed savedDogBreed = dogBreedRepository.save(dogBreed);
 
@@ -234,7 +229,6 @@ public class DogBreedRestControllerIT {
         dogBreedCreateDTO.setFemaleWeightMin(14D);
         dogBreedCreateDTO.setFemaleWeightMax(18D);
         dogBreedCreateDTO.setHypoallergenic(true);
-        dogBreedCreateDTO.setSize("Médio");
 
         Long createdDogBreedId =
         given()
@@ -253,7 +247,6 @@ public class DogBreedRestControllerIT {
                 .body("femaleWeightMin", equalTo(dogBreedCreateDTO.getFemaleWeightMin().floatValue()))
                 .body("femaleWeightMax", equalTo(dogBreedCreateDTO.getFemaleWeightMax().floatValue()))
                 .body("hypoallergenic", equalTo(dogBreedCreateDTO.getHypoallergenic()))
-                .body("size", equalTo(dogBreedCreateDTO.getSize()))
                 .extract()
                 .jsonPath()
                 .getLong("id");
@@ -274,7 +267,6 @@ public class DogBreedRestControllerIT {
         dogBreedCreateDTO.setFemaleWeightMin(null);
         dogBreedCreateDTO.setFemaleWeightMax(-2D);
         dogBreedCreateDTO.setHypoallergenic(null);
-        dogBreedCreateDTO.setSize("");
 
                 given()
                         .contentType("application/json")
@@ -304,7 +296,6 @@ public class DogBreedRestControllerIT {
         dogBreed.setFemaleWeightMin(7.0D);
         dogBreed.setFemaleWeightMax(11.0D);
         dogBreed.setHypoallergenic(true);
-        dogBreed.setSize("Médio");
 
         dogBreedRepository.save(dogBreed);
 
@@ -332,7 +323,6 @@ public class DogBreedRestControllerIT {
         dogBreed.setFemaleWeightMin(4.0D);
         dogBreed.setFemaleWeightMax(9.0D);
         dogBreed.setHypoallergenic(false);
-        dogBreed.setSize("Médio");
 
         dogBreedRepository.save(dogBreed);
 
@@ -362,7 +352,6 @@ public class DogBreedRestControllerIT {
         dogBreed.setFemaleWeightMin(4.0D);
         dogBreed.setFemaleWeightMax(9.0D);
         dogBreed.setHypoallergenic(false);
-        dogBreed.setSize("Médio");
 
         dogBreedRepository.save(dogBreed);
 
@@ -375,7 +364,6 @@ public class DogBreedRestControllerIT {
         updateDTO.setFemaleWeightMin(5.0D);
         updateDTO.setFemaleWeightMax(10.0D);
         updateDTO.setHypoallergenic(true);
-        updateDTO.setSize("Grande");
 
         given()
                 .pathParam("id", dogBreed.getId())
@@ -398,7 +386,6 @@ public class DogBreedRestControllerIT {
         assertEquals(5.0D, updatedDogBreed.getFemaleWeightMin());
         assertEquals(10.0D, updatedDogBreed.getFemaleWeightMax());
         assertEquals(true, updatedDogBreed.getHypoallergenic());
-        assertEquals("Grande", updatedDogBreed.getSize());
     }
 
     @Test
@@ -414,7 +401,6 @@ public class DogBreedRestControllerIT {
         dogBreed.setFemaleWeightMin(4.0D);
         dogBreed.setFemaleWeightMax(9.0D);
         dogBreed.setHypoallergenic(false);
-        dogBreed.setSize("Médio");
 
         dogBreedRepository.save(dogBreed);
 
@@ -427,7 +413,6 @@ public class DogBreedRestControllerIT {
         updateDTO.setFemaleWeightMin(5.0D);
         updateDTO.setFemaleWeightMax(10.0D);
         updateDTO.setHypoallergenic(true);
-        updateDTO.setSize("Grande");
 
         given()
                 .pathParam("id", "abc")
@@ -448,7 +433,6 @@ public class DogBreedRestControllerIT {
         assertEquals(4.0D, existingBreed.getFemaleWeightMin());
         assertEquals(9.0D, existingBreed.getFemaleWeightMax());
         assertFalse(existingBreed.getHypoallergenic());
-        assertEquals("Médio", existingBreed.getSize());
     }
 
     @Test
@@ -464,7 +448,6 @@ public class DogBreedRestControllerIT {
         dogBreed.setFemaleWeightMin(4.0D);
         dogBreed.setFemaleWeightMax(9.0D);
         dogBreed.setHypoallergenic(false);
-        dogBreed.setSize("Médio");
 
         dogBreedRepository.save(dogBreed);
 
@@ -477,7 +460,6 @@ public class DogBreedRestControllerIT {
         updateDTO.setFemaleWeightMin(5.0D);
         updateDTO.setFemaleWeightMax(10.0D);
         updateDTO.setHypoallergenic(true);
-        updateDTO.setSize("Grande");
 
         given()
                 .pathParam("id", 999L)
@@ -498,7 +480,6 @@ public class DogBreedRestControllerIT {
         assertEquals(4.0D, existingBreed.getFemaleWeightMin());
         assertEquals(9.0D, existingBreed.getFemaleWeightMax());
         assertFalse(existingBreed.getHypoallergenic());
-        assertEquals("Médio", existingBreed.getSize());
     }
 
     @Test

--- a/src/test/java/com/project/vetdata/controller/DogBreedRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/DogBreedRestControllerTest.java
@@ -12,7 +12,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.*;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -59,9 +58,9 @@ public class DogBreedRestControllerTest {
     @Test
     public void given_validDogBreed_when_createDogBreed_then_returnsCreatedDogBreed() throws Exception {
        DogBreedCreateDTO dogBreedCreateDTO = new DogBreedCreateDTO("Bulldog", "Amigavel e Corajoso", 8, 10, 20.0,
-               25.0, 18.0, 23.0, false,"Médio");
+               25.0, 18.0, 23.0, false);
        DogBreed dogBreed = new DogBreed(null, null, "Bulldog", "Amigavel e Corajoso", 8, 10, 20.0,
-               25.0, 18.0, 23.0, false,"Médio");
+               25.0, 18.0, 23.0, false);
 
         when(dogBreedService.createDogBreed(any(DogBreedCreateDTO.class))).thenReturn(dogBreed);
 
@@ -77,8 +76,7 @@ public class DogBreedRestControllerTest {
                 .andExpect(jsonPath("$.maleWeightMax").value(dogBreed.getMaleWeightMax()))
                 .andExpect(jsonPath("$.femaleWeightMin").value(dogBreed.getFemaleWeightMin()))
                 .andExpect(jsonPath("$.femaleWeightMax").value(dogBreed.getFemaleWeightMax()))
-                .andExpect(jsonPath("$.hypoallergenic").value(dogBreed.getHypoallergenic()))
-                .andExpect(jsonPath("$.size").value(dogBreed.getSize()));
+                .andExpect(jsonPath("$.hypoallergenic").value(dogBreed.getHypoallergenic()));
     }
 
     @Test
@@ -93,7 +91,6 @@ public class DogBreedRestControllerTest {
         dogBreedCreateDTO.setFemaleWeightMin(-18.0);
         dogBreedCreateDTO.setFemaleWeightMax(-23.0);
         dogBreedCreateDTO.setHypoallergenic(false);
-        dogBreedCreateDTO.setSize(null);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/breeds")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -105,14 +102,13 @@ public class DogBreedRestControllerTest {
                 .andExpect(jsonPath("$.maleWeightMin").value("Campo deve ter valor maior que: 0"))
                 .andExpect(jsonPath("$.maleWeightMax").value("Campo deve ter valor maior que: 0"))
                 .andExpect(jsonPath("$.femaleWeightMin").value("Campo deve ter valor maior que: 0"))
-                .andExpect(jsonPath("$.femaleWeightMax").value("Campo deve ter valor maior que: 0"))
-                .andExpect(jsonPath("$.size").value("Campo Obrigatório"));
+                .andExpect(jsonPath("$.femaleWeightMax").value("Campo deve ter valor maior que: 0"));
     }
 
     @Test
     public void given_validDogBreedId_when_getBreedById_then_returnsDogBreed() throws Exception {
         DogBreed dogBreed = new DogBreed(12345L, null ,"Bulldog", "Amigavel e Corajoso", 8, 10,
-                20.0, 25.0, 18.0, 23.0, false, "Médio");
+                20.0, 25.0, 18.0, 23.0, false);
 
         when(dogBreedService.getDogBreedId(12345L)).thenReturn(Optional.of(dogBreed));
 
@@ -128,8 +124,7 @@ public class DogBreedRestControllerTest {
                 .andExpect(jsonPath("$.maleWeightMax").value(25.0))
                 .andExpect(jsonPath("$.femaleWeightMin").value(18.0))
                 .andExpect(jsonPath("$.femaleWeightMax").value(23.0))
-                .andExpect(jsonPath("$.hypoallergenic").value(false))
-                .andExpect(jsonPath("$.size").value("Médio"));
+                .andExpect(jsonPath("$.hypoallergenic").value(false));
 
     }
 
@@ -144,7 +139,7 @@ public class DogBreedRestControllerTest {
     @Test
     public void given_dogBreedExists_when_deleteBreedById_then_returnsNoContent() throws Exception {
         DogBreed dogBreed = new DogBreed(12345L, null,"Bulldog", "Amigavel e Corajoso", 8, 10,
-                20.0, 25.0, 18.0, 23.0, false, "Médio");
+                20.0, 25.0, 18.0, 23.0, false);
 
         when(dogBreedService.getDogBreedId(12345L)).thenReturn(Optional.of(dogBreed));
 
@@ -172,10 +167,9 @@ public class DogBreedRestControllerTest {
         dogBreedUpdateDTO.setFemaleWeightMin(20.0);
         dogBreedUpdateDTO.setFemaleWeightMax(26.0);
         dogBreedUpdateDTO.setHypoallergenic(true);
-        dogBreedUpdateDTO.setSize("Pequeno");
 
         DogBreed updatedDogBreed = new DogBreed(12345L, null,"Bulldog", "Leal e Protetor", 9, 12,
-                22.0, 28.0, 20.0, 26.0, true, "Pequeno");
+                22.0, 28.0, 20.0, 26.0, true);
 
         when(dogBreedService.updateDogBreed(anyLong(), any(DogBreedUpdateDTO.class))).thenReturn(updatedDogBreed);
 
@@ -192,17 +186,16 @@ public class DogBreedRestControllerTest {
                 .andExpect(jsonPath("$.maleWeightMax").value(28.0))
                 .andExpect(jsonPath("$.femaleWeightMin").value(20.0))
                 .andExpect(jsonPath("$.femaleWeightMax").value(26.0))
-                .andExpect(jsonPath("$.hypoallergenic").value(true))
-                .andExpect(jsonPath("$.size").value("Pequeno"));
+                .andExpect(jsonPath("$.hypoallergenic").value(true));
     }
 
     @Test
     public void given_pageRequestAndBreedsExist_when_getBreedsPage_then_returnsBreedsPage() throws Exception {
         List<DogBreed> breeds = List.of(
                 new DogBreed(12345L, null,"Golden Retriever", "Amigável e inteligente", 10, 12, 29.0,
-                        34.0, 25.0, 32.0, false, "Grande"),
+                        34.0, 25.0, 32.0, false),
                 new DogBreed(67890L, null,"Labrador Retriever", "Raça popular conhecida por sua natureza amigável", 10,
-                        12, 29.0, 36.0, 25.0, 32.0, false, "Grande")
+                        12, 29.0, 36.0, 25.0, 32.0, false)
         );
         Pageable paging = PageRequest.of(0, 2, Sort.by("id"));
         Page<DogBreed> pageBreeds = new PageImpl<>(breeds, paging, breeds.size());

--- a/src/test/java/com/project/vetdata/controller/HealthRecordControllerIT.java
+++ b/src/test/java/com/project/vetdata/controller/HealthRecordControllerIT.java
@@ -86,7 +86,7 @@ public class HealthRecordControllerIT {
     public void given_valid_healthRecordCreateDTO_when_create_healthRecord_then_returns_created() {
         DogBreed dogBreed = new DogBreed(null, "2", "Pug", "Amigável e inteligente e esperto",
                 10, 12, 30D, 34D, 25D, 29D,
-                false, "Medio");
+                false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecordCreateDTO dto = new HealthRecordCreateDTO();
@@ -157,7 +157,7 @@ public class HealthRecordControllerIT {
     @Test
     public void given_valid_healthRecordId_and_valid_data_when_updateHealthRecord_then_returns_updatedHealthRecord() {
         DogBreed dogBreed = new DogBreed(null, "2", "Pug", "Amigável e inteligente e esperto",
-                10, 12, 30D, 34D, 25D, 29D, false, "Medio");
+                10, 12, 30D, 34D, 25D, 29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord record = new HealthRecord();
@@ -219,7 +219,7 @@ public class HealthRecordControllerIT {
     @Test
     public void given_invalid_id_when_updateHealthRecord_then_returns_badRequest() {
         DogBreed dogBreed = new DogBreed(null, "2", "Pug", "Amigável e inteligente e esperto",
-                10, 12, 30D, 34D, 25D, 29D, false, "Medio");
+                10, 12, 30D, 34D, 25D, 29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord record = new HealthRecord();
@@ -274,7 +274,7 @@ public class HealthRecordControllerIT {
     @Test
     public void given_non_existent_healthRecordId_when_updateHealthRecord_then_returns_notFound() {
         DogBreed dogBreed = new DogBreed(null, "2", "Pug", "Amigável e inteligente e esperto",
-                10, 12, 30D, 34D, 25D, 29D, false, "Medio");
+                10, 12, 30D, 34D, 25D, 29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord record = new HealthRecord();
@@ -329,7 +329,7 @@ public class HealthRecordControllerIT {
     @Test
     public void given_healthRecordsInDatabase_when_getAllHealthRecords_then_returnsPagedList() {
         DogBreed dogBreed = new DogBreed(null, "2", "Pug", "Amigável e inteligente e esperto",
-                10, 12, 30D, 34D, 25D, 29D, false, "Medio");
+                10, 12, 30D, 34D, 25D, 29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord record1 = new HealthRecord();
@@ -404,7 +404,7 @@ public class HealthRecordControllerIT {
     @Test
     public void given_existing_healthRecordId_when_deleteHealthRecord_then_returnsNoContent() {
         DogBreed dogBreed = new DogBreed(null, "2", "Pug", "Amigável e inteligente e esperto",
-                10, 12, 30D, 34D, 25D, 29D, false, "Medio");
+                10, 12, 30D, 34D, 25D, 29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord record = new HealthRecord();
@@ -435,7 +435,7 @@ public class HealthRecordControllerIT {
     @Test
     public void given_non_existing_healthRecordId_when_deleteHealthRecord_then_returns_notFound() {
         DogBreed dogBreed = new DogBreed(null, "2", "Pug", "Amigável e inteligente e esperto",
-                10, 12, 30D, 34D, 25D, 29D, false, "Medio");
+                10, 12, 30D, 34D, 25D, 29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord record = new HealthRecord();
@@ -468,7 +468,7 @@ public class HealthRecordControllerIT {
     @Test
     public void given_valid_id_when_getHealthRecordById_then_returns_healthRecord() {
         DogBreed dogBreed = new DogBreed(null, "2", "Pug", "Amigável e inteligente e esperto",
-                10, 12, 30D, 34D, 25D, 29D, false, "Medio");
+                10, 12, 30D, 34D, 25D, 29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord record = new HealthRecord();

--- a/src/test/java/com/project/vetdata/controller/HealthRecordRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/HealthRecordRestControllerTest.java
@@ -54,7 +54,7 @@ public class HealthRecordRestControllerTest {
         HealthRecord savedRecord = new HealthRecord(10L, dto.getAge(), dto.getCodPatient(), dto.getColor(), dto.getDeath(), dto.getEuthanasia(),
                 dto.getGender(), dto.getPatient(), dto.getSize(), dto.getTutor(), dto.getWeight(), new DogBreed(1L, "123", "Labrador",
                 "Amigavel e Corajoso", 8, 10, 20.0, 25.0, 18.0, 23.0,
-                false,"Médio"));
+                false));
 
         when(healthRecordService.createHealthRecord(any(HealthRecordCreateDTO.class))).thenReturn(savedRecord);
 
@@ -117,7 +117,7 @@ public class HealthRecordRestControllerTest {
                 updateDTO.getTutor(),
                 updateDTO.getWeight(),
                 new DogBreed(2L, "456", "Poodle", "Inteligente e Ativo", 12, 15,
-                        10.0, 12.0, 8.0, 10.0, false, "Pequeno")
+                        10.0, 12.0, 8.0, 10.0, false)
         );
 
         when(healthRecordService.updateHealthRecord(eq(123L), any(HealthRecordUpdateDTO.class)))
@@ -190,11 +190,11 @@ public class HealthRecordRestControllerTest {
                 new HealthRecord(1L, 3.0, "C001", "Preto", false, Euthanasia.NO,
                         Gender.FEMALE, "Cacau", DogSize.SMALL, "Andrea", 10.0,
                         new DogBreed(1L, "001", "Beagle", "Curioso", 10, 12,
-                                10.0, 15.0, 8.0, 12.0, false, "Pequeno")),
+                                10.0, 15.0, 8.0, 12.0, false)),
                 new HealthRecord(2L, 4.0, "C002", "Marrom", false, Euthanasia.NO,
                         Gender.MALE, "Nutella", DogSize.MEDIUM, "Aline", 14.0,
                         new DogBreed(2L, "002", "Boxer", "Brincalhão", 9, 11,
-                                25.0, 32.0, 22.0, 30.0, false, "Médio"))
+                                25.0, 32.0, 22.0, 30.0, false))
         );
 
         Pageable paging = PageRequest.of(0, 2, Sort.by("id"));
@@ -229,7 +229,7 @@ public class HealthRecordRestControllerTest {
                 new HealthRecord(3L, 2.0, "C003", "Branco", false, Euthanasia.NO,
                         Gender.FEMALE, "Cacau", DogSize.SMALL, "Andrea", 11.0,
                         new DogBreed(3L, "003", "Shih Tzu", "Fofo e tranquilo", 10, 13,
-                                6.0, 8.0, 5.0, 7.0, false, "Pequeno"))
+                                6.0, 8.0, 5.0, 7.0, false))
         );
 
         Pageable paging = PageRequest.of(0, 10, Sort.by("id"));
@@ -256,7 +256,7 @@ public class HealthRecordRestControllerTest {
         HealthRecord existingRecord = new HealthRecord(healthRecordId,
                 4.0,"C357","Preto", false, Euthanasia.NO, Gender.MALE, "Nutella", DogSize.MEDIUM, "Clovis", 12.0,
                 new DogBreed(1L, "001", "Labrador", "Companheiro", 10, 12,
-                        25.0, 30.0, 22.0, 28.0, false, "Médio"));
+                        25.0, 30.0, 22.0, 28.0, false));
 
         when(healthRecordService.getHealthRecordById(healthRecordId)).thenReturn(Optional.of(existingRecord));
 
@@ -282,7 +282,7 @@ public class HealthRecordRestControllerTest {
         HealthRecord existingRecord = new HealthRecord(healthRecordId,
                 4.0,"C357","Preto", false, Euthanasia.NO, Gender.MALE, "Nutella", DogSize.MEDIUM, "Clovis", 12.0,
                 new DogBreed(1L, "001", "Labrador", "Companheiro", 10, 12,
-                        25.0, 30.0, 22.0, 28.0, false, "Médio"));
+                        25.0, 30.0, 22.0, 28.0, false));
 
         when(healthRecordService.getHealthRecordById(healthRecordId)).thenReturn(Optional.of(existingRecord));
 

--- a/src/test/java/com/project/vetdata/controller/HospitalAdmissionControllerIT.java
+++ b/src/test/java/com/project/vetdata/controller/HospitalAdmissionControllerIT.java
@@ -93,7 +93,7 @@ public class HospitalAdmissionControllerIT {
     @Test
     public void given_valid_hospitalAdmissionCreateDTO_when_createHospitalAdmission_then_returns_created() {
         DogBreed dogBreed = new DogBreed(null, "1", "Pug", "Amigável", 10, 12, 30D, 34D, 25D,
-                29D, false, "Grande");
+                29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
@@ -175,7 +175,7 @@ public class HospitalAdmissionControllerIT {
     @Test
     public void given_valid_hospitalAdmissionId_and_data_valid_updateHospitalAdmission_then_returns_updateAdmission() {
         DogBreed dogBreed = new DogBreed(null, "1", "Pug", "Amigável", 10, 12, 30D, 34D, 25D,
-                29D, false, "Grande");
+                29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
@@ -244,7 +244,7 @@ public class HospitalAdmissionControllerIT {
     @Test
     public void given_invalid_hospitalAdmissionId_and_invalid_data_when_updateHospitalAdmission_then_returns_badRequest() {
         DogBreed dogBreed = new DogBreed(null, "1", "Pug", "Amigável", 10, 12, 30D, 34D, 25D,
-                29D, false, "Grande");
+                29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
@@ -293,7 +293,7 @@ public class HospitalAdmissionControllerIT {
     @Test
     public void given_hospitalAdmissionsInDatabase_when_getAllHospitalAdmissions_then_returnsPagedList() {
         DogBreed dogBreed = new DogBreed(null, "1", "Pug", "Amigável", 10, 12, 30D, 34D, 25D,
-                29D, false, "Grande");
+                29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
@@ -366,7 +366,7 @@ public class HospitalAdmissionControllerIT {
     @Test
     public void given_existing_hospitalAdmissionId_when_deleteHospitalAdmission_then_returnsNoContent() {
         DogBreed dogBreed = new DogBreed(null, "1", "Pug", "Amigável", 10, 12, 30D, 34D, 25D,
-                29D, false, "Grande");
+                29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
@@ -405,7 +405,7 @@ public class HospitalAdmissionControllerIT {
     @Test
     public void given_non_existing_hospitalAdmissionId_when_deleteHospitalAdmission_then_returns_notFound() {
         DogBreed dogBreed = new DogBreed(null, "1", "Pug", "Amigável", 10, 12, 30D, 34D, 25D,
-                29D, false, "Grande");
+                29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,
@@ -447,7 +447,7 @@ public class HospitalAdmissionControllerIT {
     @Test
     public void given_valid_id_when_getHospitalAdmissionById_then_returns_hospitalAdmission() {
         DogBreed dogBreed = new DogBreed(null, "1", "Pug", "Amigável", 10, 12, 30D, 34D, 25D,
-                29D, false, "Grande");
+                29D, false);
         DogBreed savedBreed = dogBreedRepository.save(dogBreed);
 
         HealthRecord healthRecord = new HealthRecord(null, 4.0, "P01", "Preto", false, Euthanasia.NO, Gender.MALE,

--- a/src/test/java/com/project/vetdata/service/DogBreedExternalServiceTest.java
+++ b/src/test/java/com/project/vetdata/service/DogBreedExternalServiceTest.java
@@ -104,7 +104,6 @@ public class DogBreedExternalServiceTest {
         assertEquals(existingBreed.getFemaleWeightMin(), updateDTO.getFemaleWeightMin(), "O peso mínimo da fêmea deve ser o mesmo");
         assertEquals(existingBreed.getFemaleWeightMax(), updateDTO.getFemaleWeightMax(), "O peso máximo da fêmea deve ser o mesmo");
         assertEquals(existingBreed.getHypoallergenic(), updateDTO.getHypoallergenic(), "A informação de hipoalergenicidade deve ser a mesma");
-        assertEquals(existingBreed.getSize(), updateDTO.getSize(), "O tamanho deve ser o mesmo (mesmo que esteja nulo)");
     }
 
     @Test
@@ -254,7 +253,6 @@ public class DogBreedExternalServiceTest {
         dogBreed.setFemaleWeightMin(27D);
         dogBreed.setFemaleWeightMax(33D);
         dogBreed.setHypoallergenic(false);
-        dogBreed.setSize(null);
         return dogBreed;
     }
 }

--- a/src/test/java/com/project/vetdata/service/DogBreedServiceImplIT.java
+++ b/src/test/java/com/project/vetdata/service/DogBreedServiceImplIT.java
@@ -262,7 +262,6 @@ public class DogBreedServiceImplIT {
         dogBreed.setFemaleWeightMin(27D);
         dogBreed.setFemaleWeightMax(33D);
         dogBreed.setHypoallergenic(false);
-        dogBreed.setSize(null);
         return dogBreed;
     }
 
@@ -278,7 +277,6 @@ public class DogBreedServiceImplIT {
         dogBreed.setFemaleWeightMin(27D);
         dogBreed.setFemaleWeightMax(33D);
         dogBreed.setHypoallergenic(false);
-        dogBreed.setSize(null);
         return dogBreed;
     }
 
@@ -294,7 +292,6 @@ public class DogBreedServiceImplIT {
         dogBreed.setFemaleWeightMin(27D);
         dogBreed.setFemaleWeightMax(33D);
         dogBreed.setHypoallergenic(false);
-        dogBreed.setSize(null);
         return dogBreed;
     }
 
@@ -309,7 +306,6 @@ public class DogBreedServiceImplIT {
         dogBreedCreateDTO.setFemaleWeightMin(27D);
         dogBreedCreateDTO.setFemaleWeightMax(33D);
         dogBreedCreateDTO.setHypoallergenic(false);
-        dogBreedCreateDTO.setSize("Médio");
         return dogBreedCreateDTO;
     }
 
@@ -324,7 +320,6 @@ public class DogBreedServiceImplIT {
         dogBreedCreateDTO.setFemaleWeightMin(27D);
         dogBreedCreateDTO.setFemaleWeightMax(33D);
         dogBreedCreateDTO.setHypoallergenic(false);
-        dogBreedCreateDTO.setSize("Médio");
         return dogBreedCreateDTO;
     }
 }

--- a/src/test/java/com/project/vetdata/service/DogBreedServiceImplTest.java
+++ b/src/test/java/com/project/vetdata/service/DogBreedServiceImplTest.java
@@ -161,7 +161,6 @@ public class DogBreedServiceImplTest {
         assertEquals(updatedBreed.getFemaleWeightMin(), updatedBreed.getFemaleWeightMin(), "O peso mínimo das femeas deve ser atualizado");
         assertEquals(updatedBreed.getFemaleWeightMax(), updatedBreed.getFemaleWeightMax(), "O peso máximo das femeas deve ser atualizado");
         assertEquals(updatedBreed.getHypoallergenic(), updatedBreed.getHypoallergenic(), "A propriedade hipoalergênica deve ser atualizada");
-        assertEquals(updatedBreed.getSize(), updatedBreed.getSize(), "O tamanho deve ser atualizado");
     }
 
     @Test
@@ -204,7 +203,6 @@ public class DogBreedServiceImplTest {
         assertEquals(updateDTO.getFemaleWeightMin(), updatedBreed.getFemaleWeightMin(), "O peso mínimo das fêmeas deve ser atualizado");
         assertEquals(updateDTO.getFemaleWeightMax(), updatedBreed.getFemaleWeightMax(), "O peso máximo das fêmeas deve ser atualizado");
         assertEquals(updateDTO.getHypoallergenic(), updatedBreed.getHypoallergenic(), "A propriedade hipoalergênica deve ser atualizada");
-        assertEquals(updateDTO.getSize(), updatedBreed.getSize(), "O tamanho deve ser atualizado");
     }
 
     @Test
@@ -229,7 +227,6 @@ public class DogBreedServiceImplTest {
         assertEquals(existingBreed.getFemaleWeightMin(), updatedBreed.getFemaleWeightMin(), "O peso mínimo das fêmeas existente deve ser mantido");
         assertEquals(existingBreed.getFemaleWeightMax(), updatedBreed.getFemaleWeightMax(), "O peso máximo das fêmeas existente deve ser mantido");
         assertEquals(existingBreed.getHypoallergenic(), updatedBreed.getHypoallergenic(), "A propriedade hipoalergênica existente deve ser mantida");
-        assertEquals(existingBreed.getSize(), updatedBreed.getSize(), "O tamanho existente deve ser mantido");
     }
 
     @Test
@@ -257,19 +254,19 @@ public class DogBreedServiceImplTest {
     public DogBreed getFakeDogBreed() {
         return new DogBreed(1L, "2", "Golden Retriever", "Amigável e inteligente e esperto",
                 10, 12, 30D, 34D, 25D, 29D,
-                false, "Medio");
+                false);
     }
 
     public DogBreed getFakeDogBreed2() {
         return new DogBreed(2L, "3", "Labrador", "Amigável e inteligente e esperto",
                 10, 12, 30D, 34D, 25D, 29D,
-                false, "Medio");
+                false);
     }
 
     public DogBreed getFakeDogBreed3() {
         return new DogBreed(3L, "4", "Lhasa Apso", "Amigável e inteligente e esperto",
                 10, 12, 30D, 34D, 25D, 29D,
-                false, "Medio");
+                false);
     }
 
     public DogBreedCreateDTO getFakeDogBreedCreateDTO() {
@@ -283,7 +280,6 @@ public class DogBreedServiceImplTest {
         dto.setFemaleWeightMin(25D);
         dto.setFemaleWeightMax(29D);
         dto.setHypoallergenic(false);
-        dto.setSize("Médio");
         return dto;
     }
 
@@ -297,7 +293,6 @@ public class DogBreedServiceImplTest {
         updateDTO.setFemaleWeightMin(26D);
         updateDTO.setFemaleWeightMax(29D);
         updateDTO.setHypoallergenic(true);
-        updateDTO.setSize("Médio");
         return updateDTO;
     }
 }

--- a/src/test/java/com/project/vetdata/service/HealthRecordServiceImplIT.java
+++ b/src/test/java/com/project/vetdata/service/HealthRecordServiceImplIT.java
@@ -277,7 +277,6 @@ public class HealthRecordServiceImplIT {
         breed.setMaleWeightMax(34.0);
         breed.setFemaleWeightMin(28.0);
         breed.setFemaleWeightMax(32.0);
-        breed.setSize("Grande");
         breed.setHypoallergenic(false);
         return breed;
     }

--- a/src/test/java/com/project/vetdata/service/HealthRecordServiceImplTest.java
+++ b/src/test/java/com/project/vetdata/service/HealthRecordServiceImplTest.java
@@ -233,7 +233,7 @@ public class HealthRecordServiceImplTest {
     public DogBreed getFakeDogBreed() {
         return new DogBreed(1L, "2", "Golden Retriever", "Amigável e inteligente e esperto",
                 10, 12, 30D, 34D, 25D, 29D,
-                false, "Medio");
+                false);
     }
 
     private HealthRecord getFakeHealthRecord() {
@@ -266,7 +266,6 @@ public class HealthRecordServiceImplTest {
         dto.setGender(Gender.FEMALE);
         dto.setDeath(false);
         dto.setEuthanasia(Euthanasia.NO);
-
         return dto;
     }
 }

--- a/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplIT.java
+++ b/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplIT.java
@@ -14,9 +14,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
@@ -334,7 +331,6 @@ public class HospitalAdmissionServiceImplIT {
         breed.setMaleWeightMax(8.0);
         breed.setFemaleWeightMin(6.0);
         breed.setFemaleWeightMax(8.0);
-        breed.setSize("Pequeno");
         breed.setHypoallergenic(false);
         return breed;
     }

--- a/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplTest.java
+++ b/src/test/java/com/project/vetdata/service/HospitalAdmissionServiceImplTest.java
@@ -362,7 +362,7 @@ public class HospitalAdmissionServiceImplTest {
     public DogBreed getFakeDogBreed() {
         return new DogBreed(1L, "2", "Golden Retriever", "Amigável e inteligente e esperto",
                 10, 12, 30D, 34D, 25D, 29D,
-                false, "Medio");
+                false);
     }
 
     private Diagnostic getFakeDiagnostic() {


### PR DESCRIPTION
# Remove Dog Size Field

## Type
- [ ] Hotfix
- [ ] New feature
- [x] Refactor / Improvements

## Context
- Removido o campo size da entidade DogBreed.
- Atualizados os DTOs, mappers, serviços, testes e controladores.
- Criado o AuthenticationResponseDTO com status de autenticação e nome do usuário.

### Coverage Tests
![2](https://github.com/user-attachments/assets/d5a01d72-5a23-41e1-a435-00791bb05a69)


### Checklist
- [x] Remover atributo size da entidade DogBreed.
- [x] Atualizar construtores, getters e setters.
- [x] Garantir que testes continuem passando.