### PR TITLE
Fix swagger update springdoc and Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.2</version>
+        <version>3.4.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.project</groupId>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/project/vetdata/controller/UserRestController.java
+++ b/src/main/java/com/project/vetdata/controller/UserRestController.java
@@ -40,7 +40,7 @@ public class UserRestController {
     @Operation(summary = "Remover usuário por ID")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Usuário removido!"),
-            @ApiResponse(responseCode = "404", description = "Usuário não encontrada!", content = @Content)
+            @ApiResponse(responseCode = "404", description = "Usuário não encontrado!", content = @Content)
     })
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteUser(@PathVariable Long id) {


### PR DESCRIPTION
# Fix Swagger Docs Compatibility

## Type
- [ ] Hotfix
- [ ] New feature
- [x] Refactor / Improvements

## Context
- Ajustada a compatibilidade entre `springdoc-openapi` e `Spring Boot`.
- Corrigido o erro `NoSuchMethodError` ao carregar a rota `/v3/api-docs`.

### Coverage Tests
![2](https://github.com/user-attachments/assets/0d7b57bb-2a70-4045-8ca2-86db752b2bd1)


### Checklist
- [x] Alterar versão do Spring Boot para 3.4.1.
- [x] Alterar versão do springdoc-openapi para 2.7.0.
- [x] Confirmar que a documentação da API é carregada corretamente.