### PR TITLE
Created search endpoint with pagination in Post Operative

### DIFF
--- a/src/main/java/com/project/vetdata/controller/DiagnosticRestController.java
+++ b/src/main/java/com/project/vetdata/controller/DiagnosticRestController.java
@@ -9,11 +9,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/diagnostics")
@@ -64,5 +70,38 @@ public class DiagnosticRestController {
     public ResponseEntity<List<Diagnostic>> getAllDiagnostics() {
         List<Diagnostic> diagnostics = service.getAllDiagnostics();
         return ResponseEntity.ok(diagnostics);
+    }
+
+    @Operation(summary = "Buscar todos os diagnósticos (com paginação e busca)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Diagnóstico(s) encontrado(s)!",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = Diagnostic.class))}),
+            @ApiResponse(responseCode = "204", description = "Nenhum diagnóstico encontrado!", content = @Content)
+    })
+    @GetMapping("/search")
+    public ResponseEntity<Map<String, Object>> getAllDiagnosticsPaginated(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int qtdRecordsPage,
+            @RequestParam(defaultValue = "id") String sortBy,
+            @RequestParam(required = false) String searchByTerm
+    ) {
+        Pageable pageable = PageRequest.of(page, qtdRecordsPage, Sort.by(sortBy));
+        Page<Diagnostic> diagnosticsPage = StringUtils.hasText(searchByTerm)
+                ? service.getBySearchTerm(searchByTerm, pageable)
+                : service.getAllDiagnosticsPaginated(pageable);
+
+        if (diagnosticsPage.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        Map<String, Object> response = Map.of(
+                "total", diagnosticsPage.getTotalElements(),
+                "qtdRecordsPage", diagnosticsPage.getSize(),
+                "page", diagnosticsPage.getNumber(),
+                "data", diagnosticsPage.getContent()
+        );
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/project/vetdata/controller/PostOperativeRestController.java
+++ b/src/main/java/com/project/vetdata/controller/PostOperativeRestController.java
@@ -9,11 +9,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/post-operatives")
@@ -64,5 +70,38 @@ public class PostOperativeRestController {
     public ResponseEntity<List<PostOperative>> getAllPostOperatives() {
         List<PostOperative> postOperatives = service.getAllPostOperatives();
         return ResponseEntity.ok(postOperatives);
+    }
+
+    @Operation(summary = "Buscar todos os pós-operatórios (com paginação e busca)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pós-operatório(s) encontrado(s)!",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = PostOperative.class))}),
+            @ApiResponse(responseCode = "204", description = "Nenhum pós-operatório encontrado!", content = @Content)
+    })
+    @GetMapping("/search")
+    public ResponseEntity<Map<String, Object>> getAllPostOperativesPaginated(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int qtdRecordsPage,
+            @RequestParam(defaultValue = "id") String sortBy,
+            @RequestParam(required = false) String searchByTerm
+    ) {
+        Pageable pageable = PageRequest.of(page, qtdRecordsPage, Sort.by(sortBy));
+        Page<PostOperative> postOperativesPage = StringUtils.hasText(searchByTerm)
+                ? service.getBySearchTerm(searchByTerm, pageable)
+                : service.getAllPostOperativesPaginated(pageable);
+
+        if (postOperativesPage.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        Map<String, Object> response = Map.of(
+                "total", postOperativesPage.getTotalElements(),
+                "qtdRecordsPage", postOperativesPage.getSize(),
+                "page", postOperativesPage.getNumber(),
+                "data", postOperativesPage.getContent()
+        );
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/project/vetdata/repository/DiagnosticRepository.java
+++ b/src/main/java/com/project/vetdata/repository/DiagnosticRepository.java
@@ -2,11 +2,14 @@ package com.project.vetdata.repository;
 
 import com.project.vetdata.model.Diagnostic;
 import com.project.vetdata.model.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Page;
 
 import java.util.Optional;
 
 @Repository
 public interface DiagnosticRepository extends JpaRepository<Diagnostic, Long> {
+    Page<Diagnostic> findByDescriptionContainingIgnoreCase(String term, Pageable pageable);
 }

--- a/src/main/java/com/project/vetdata/repository/PostOperativeRepository.java
+++ b/src/main/java/com/project/vetdata/repository/PostOperativeRepository.java
@@ -1,10 +1,12 @@
 package com.project.vetdata.repository;
 
-import com.project.vetdata.model.Diagnostic;
 import com.project.vetdata.model.PostOperative;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Page;
 
 @Repository
 public interface PostOperativeRepository extends JpaRepository<PostOperative, Long> {
+    Page<PostOperative> findByDescriptionContainingIgnoreCase(String term, Pageable pageable);
 }

--- a/src/main/java/com/project/vetdata/service/DiagnosticService.java
+++ b/src/main/java/com/project/vetdata/service/DiagnosticService.java
@@ -5,6 +5,8 @@ import com.project.vetdata.mappers.MapperDTOToEntity;
 import com.project.vetdata.model.Diagnostic;
 import com.project.vetdata.repository.DiagnosticRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -35,5 +37,13 @@ public class DiagnosticService {
 
     public List<Diagnostic> getAllDiagnostics() {
         return repository.findAll();
+    }
+
+    public Page<Diagnostic> getAllDiagnosticsPaginated(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public Page<Diagnostic> getBySearchTerm(String term, Pageable pageable) {
+        return repository.findByDescriptionContainingIgnoreCase(term, pageable);
     }
 }

--- a/src/main/java/com/project/vetdata/service/PostOperativeService.java
+++ b/src/main/java/com/project/vetdata/service/PostOperativeService.java
@@ -8,6 +8,8 @@ import com.project.vetdata.model.PostOperative;
 import com.project.vetdata.repository.DiagnosticRepository;
 import com.project.vetdata.repository.PostOperativeRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -39,5 +41,13 @@ public class PostOperativeService {
 
     public List<PostOperative> getAllPostOperatives() {
         return repository.findAll();
+    }
+
+    public Page<PostOperative> getAllPostOperativesPaginated(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public Page<PostOperative> getBySearchTerm(String term, Pageable pageable) {
+        return repository.findByDescriptionContainingIgnoreCase(term, pageable);
     }
 }

--- a/src/test/java/com/project/vetdata/controller/DiagnosticRestControllerIT.java
+++ b/src/test/java/com/project/vetdata/controller/DiagnosticRestControllerIT.java
@@ -177,4 +177,53 @@ public class DiagnosticRestControllerIT {
                 .body("", hasSize(0))
                 .body(equalTo("[]"));
     }
+
+    @Test
+    public void given_multiple_diagnostics_when_search_without_term_then_returns_paginated_result() {
+        repository.save(DiagnosticTemplate.getFakeDiagnostic());
+        repository.save(DiagnosticTemplate.getFakeDiagnostic2());
+
+        given()
+                .queryParam("page", 0)
+                .queryParam("qtdRecordsPage", 10)
+                .queryParam("sortBy", "description")
+                .when()
+                .get("/diagnostics/search")
+                .then()
+                .statusCode(200)
+                .body("total", equalTo(2))
+                .body("qtdRecordsPage", equalTo(10))
+                .body("page", equalTo(0))
+                .body("data.size()", equalTo(2));
+    }
+
+    @Test
+    public void given_diagnostics_when_search_with_matching_term_then_returns_filtered_result() {
+        repository.save(DiagnosticTemplate.getFakeDiagnostic());
+        repository.save(DiagnosticTemplate.getFakeDiagnostic2());
+
+        given()
+                .queryParam("searchByTerm", "gri")
+                .queryParam("page", 0)
+                .queryParam("qtdRecordsPage", 10)
+                .when()
+                .get("/diagnostics/search")
+                .then()
+                .statusCode(200)
+                .body("total", equalTo(1))
+                .body("data[0].description", equalTo("Gripe"));
+    }
+
+    @Test
+    public void given_diagnostics_when_search_with_non_matching_term_then_returns_no_content() {
+        repository.save(DiagnosticTemplate.getFakeDiagnostic());
+        repository.save(DiagnosticTemplate.getFakeDiagnostic2());
+
+        given()
+                .queryParam("searchByTerm", "man")
+                .when()
+                .get("/diagnostics/search")
+                .then()
+                .statusCode(204);
+    }
 }

--- a/src/test/java/com/project/vetdata/controller/DiagnosticRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/DiagnosticRestControllerTest.java
@@ -1,0 +1,104 @@
+package com.project.vetdata.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.model.Diagnostic;
+import com.project.vetdata.service.DiagnosticService;
+import com.project.vetdata.templates.DiagnosticTemplate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(DiagnosticRestController.class)
+public class DiagnosticRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DiagnosticService diagnosticService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void given_search_term_when_getAllDiagnostics_paginated_then_call_getBySearchTerm() throws Exception {
+        String searchTerm = "gri";
+        Pageable paging = PageRequest.of(0, 10, Sort.by("id"));
+        Diagnostic diagnostic1 = DiagnosticTemplate.getFakeDiagnostic();
+        Diagnostic diagnostic2 = DiagnosticTemplate.getFakeDiagnostic2();
+        Page<Diagnostic> page = new PageImpl<>(List.of(diagnostic1, diagnostic2), paging, 2);
+
+        when(diagnosticService.getBySearchTerm(eq(searchTerm), eq(paging))).thenReturn(page);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/diagnostics/search")
+                        .param("searchByTerm", searchTerm)
+                        .param("page", "0")
+                        .param("qtdRecordsPage", "10")
+                        .param("sortBy", "id")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.qtdRecordsPage").value(10));
+
+        verify(diagnosticService).getBySearchTerm(eq(searchTerm), eq(paging));
+    }
+
+    @Test
+    public void given_no_search_term_when_getAllDiagnostics_paginated_then_call_getAllDiagnostics_paginated() throws Exception {
+        Pageable paging = PageRequest.of(0, 10, Sort.by("id"));
+        Diagnostic diagnostic = DiagnosticTemplate.getFakeDiagnostic2();
+        Page<Diagnostic> page = new PageImpl<>(List.of(diagnostic), paging, 1);
+
+        when(diagnosticService.getAllDiagnosticsPaginated(eq(paging))).thenReturn(page);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/diagnostics/search")
+                        .param("page", "0")
+                        .param("qtdRecordsPage", "10")
+                        .param("sortBy", "id")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.qtdRecordsPage").value(10));
+
+        verify(diagnosticService).getAllDiagnosticsPaginated(eq(paging));
+    }
+
+    @Test
+    public void given_emptyPage_when_getAllDiagnostics_paginated_then_return_noContent() throws Exception {
+        Pageable paging = PageRequest.of(0, 10, Sort.by("id"));
+        Page<Diagnostic> emptyPage = Page.empty();
+
+        when(diagnosticService.getAllDiagnosticsPaginated(eq(paging))).thenReturn(emptyPage);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/diagnostics/search")
+                        .param("page", "0")
+                        .param("qtdRecordsPage", "10")
+                        .param("sortBy", "id")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+
+        verify(diagnosticService).getAllDiagnosticsPaginated(eq(paging));
+    }
+
+}

--- a/src/test/java/com/project/vetdata/controller/PostOperativeRestControllerIT.java
+++ b/src/test/java/com/project/vetdata/controller/PostOperativeRestControllerIT.java
@@ -174,4 +174,53 @@ public class PostOperativeRestControllerIT {
                 .body("", hasSize(0))
                 .body(equalTo("[]"));
     }
+
+    @Test
+    public void given_multiple_postOperatives_when_search_without_term_then_returns_paginated_result() {
+        repository.save(PostOperativeTemplate.getFakePostOperative());
+        repository.save(PostOperativeTemplate.getFakePostOperative2());
+
+        given()
+                .queryParam("page", 0)
+                .queryParam("qtdRecordsPage", 10)
+                .queryParam("sortBy", "description")
+                .when()
+                .get("/post-operatives/search")
+                .then()
+                .statusCode(200)
+                .body("total", equalTo(2))
+                .body("qtdRecordsPage", equalTo(10))
+                .body("page", equalTo(0))
+                .body("data.size()", equalTo(2));
+    }
+
+    @Test
+    public void given_postOperatives_when_search_with_matching_term_then_returns_filtered_result() {
+        repository.save(PostOperativeTemplate.getFakePostOperative());
+        repository.save(PostOperativeTemplate.getFakePostOperative2());
+
+        given()
+                .queryParam("searchByTerm", "fisio")
+                .queryParam("page", 0)
+                .queryParam("qtdRecordsPage", 10)
+                .when()
+                .get("/post-operatives/search")
+                .then()
+                .statusCode(200)
+                .body("total", equalTo(1))
+                .body("data[0].description", equalTo("Fisioterapia"));
+    }
+
+    @Test
+    public void given_postOperatives_when_search_with_non_matching_term_then_returns_no_content() {
+        repository.save(PostOperativeTemplate.getFakePostOperative());
+        repository.save(PostOperativeTemplate.getFakePostOperative2());
+
+        given()
+                .queryParam("searchByTerm", "man")
+                .when()
+                .get("/post-operatives/search")
+                .then()
+                .statusCode(204);
+    }
 }

--- a/src/test/java/com/project/vetdata/controller/PostOperativeRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/PostOperativeRestControllerTest.java
@@ -1,0 +1,104 @@
+package com.project.vetdata.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.model.PostOperative;
+import com.project.vetdata.service.PostOperativeService;
+import com.project.vetdata.templates.PostOperativeTemplate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PostOperativeRestController.class)
+public class PostOperativeRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PostOperativeService postOperativeService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void given_search_term_when_getAllPostOperatives_paginated_then_call_getBySearchTerm() throws Exception {
+        String searchTerm = "fisio";
+        Pageable paging = PageRequest.of(0, 10, Sort.by("id"));
+        PostOperative post1 = PostOperativeTemplate.getFakePostOperative();
+        PostOperative post2 = PostOperativeTemplate.getFakePostOperative2();
+        Page<PostOperative> page = new PageImpl<>(List.of(post1, post2), paging, 2);
+
+        when(postOperativeService.getBySearchTerm(eq(searchTerm), eq(paging))).thenReturn(page);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/post-operatives/search")
+                        .param("searchByTerm", searchTerm)
+                        .param("page", "0")
+                        .param("qtdRecordsPage", "10")
+                        .param("sortBy", "id")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.qtdRecordsPage").value(10));
+
+        verify(postOperativeService).getBySearchTerm(eq(searchTerm), eq(paging));
+    }
+
+    @Test
+    public void given_no_search_term_when_getAllPostOperatives_paginated_then_call_getAllPostOperatives_paginated() throws Exception {
+        Pageable paging = PageRequest.of(0, 10, Sort.by("id"));
+        PostOperative post = PostOperativeTemplate.getFakePostOperative();
+        Page<PostOperative> page = new PageImpl<>(List.of(post), paging, 1);
+
+        when(postOperativeService.getAllPostOperativesPaginated(eq(paging))).thenReturn(page);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/post-operatives/search")
+                        .param("page", "0")
+                        .param("qtdRecordsPage", "10")
+                        .param("sortBy", "id")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.qtdRecordsPage").value(10));
+
+        verify(postOperativeService).getAllPostOperativesPaginated(eq(paging));
+    }
+
+    @Test
+    public void given_emptyPage_when_getAllPostOperatives_paginated_then_return_noContent() throws Exception {
+        Pageable paging = PageRequest.of(0, 10, Sort.by("id"));
+        Page<PostOperative> emptyPage = Page.empty();
+
+        when(postOperativeService.getAllPostOperativesPaginated(eq(paging))).thenReturn(emptyPage);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/post-operatives/search")
+                        .param("page", "0")
+                        .param("qtdRecordsPage", "10")
+                        .param("sortBy", "id")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+
+        verify(postOperativeService).getAllPostOperativesPaginated(eq(paging));
+    }
+}
+

--- a/src/test/java/com/project/vetdata/service/DiagnosticServiceIT.java
+++ b/src/test/java/com/project/vetdata/service/DiagnosticServiceIT.java
@@ -14,11 +14,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -125,5 +129,43 @@ public class DiagnosticServiceIT {
 
         List<String> names = result.stream().map(Diagnostic::getDescription).toList();
         assertTrue(names.contains("Cancer"));
+    }
+
+    @Test
+    public void given_multiple_diagnostics_when_getAllDiagnosticPaginated_then_return_paginated_diagnostics() {
+        service.createDiagnostic(DiagnosticTemplate.getFakeDiagnosticCreateDTO());
+        service.createDiagnostic(DiagnosticTemplate.getFakeDiagnosticCreateDTO2());
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("description"));
+        Page<Diagnostic> result = service.getAllDiagnosticsPaginated(pageable);
+
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertFalse(result.isEmpty(), "A página não deve estar vazia");
+    }
+
+    @Test
+    public void given_diagnostics_when_getBySearchTerm_with_matching_term_then_return_filtered_page() {
+        service.createDiagnostic(DiagnosticTemplate.getFakeDiagnosticCreateDTO());
+        service.createDiagnostic(DiagnosticTemplate.getFakeDiagnosticCreateDTO2());
+
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Diagnostic> result = service.getBySearchTerm("gri", pageable);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals("Gripe", result.getContent().get(0).getDescription());
+    }
+
+    @Test
+    public void given_diagnostics_when_getBySearchTerm_with_no_match_return_empty_page() {
+        service.createDiagnostic(DiagnosticTemplate.getFakeDiagnosticCreateDTO());
+        service.createDiagnostic(DiagnosticTemplate.getFakeDiagnosticCreateDTO2());
+
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Diagnostic> result = service.getBySearchTerm("Man", pageable);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty(), "A página deve estar vazia");
     }
 }

--- a/src/test/java/com/project/vetdata/service/DiagnosticServiceTest.java
+++ b/src/test/java/com/project/vetdata/service/DiagnosticServiceTest.java
@@ -10,6 +10,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Collections;
 import java.util.List;
@@ -73,5 +77,52 @@ public class DiagnosticServiceTest {
         assertNotNull(result, "A lista não deve ser nula.");
         assertTrue(result.isEmpty(), "A lista deve estar vazia");
         verify(repository, times(1)).findAll();
+    }
+
+    @Test
+    public void given_diagnostic_exist_when_getAllDiagnosticsPaginated_is_called_then_return_page_of_diagnostics() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Diagnostic diagnostic = DiagnosticTemplate.getFakeDiagnostic();
+        Page<Diagnostic> diagnosticPage = new PageImpl<>(List.of(diagnostic));
+
+        when(repository.findAll(pageable)).thenReturn(diagnosticPage);
+
+        Page<Diagnostic> result = service.getAllDiagnosticsPaginated(pageable);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(repository, times(1)).findAll(pageable);
+    }
+
+    @Test
+    public void given_matching_diagnostics_when_getBySearchTerm_is_called_then_return_page_of_matching_diagnostics() {
+        String term = "gripe";
+        Pageable pageable = PageRequest.of(0,10);
+        Diagnostic diagnostic = DiagnosticTemplate.getFakeDiagnostic();
+        Page<Diagnostic> diagnosticPage = new PageImpl<>(List.of(diagnostic));
+
+        when(repository.findByDescriptionContainingIgnoreCase(term, pageable)).thenReturn(diagnosticPage);
+
+        Page<Diagnostic> result = service.getBySearchTerm(term, pageable);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.getTotalElements());
+        verify(repository, times(1)).findByDescriptionContainingIgnoreCase(term, pageable);
+    }
+
+    @Test
+    public void given_no_matching_diagnostics_when_getBySearchTerm_is_called_then_return_empty_page() {
+        String term = "teste";
+        Pageable pageable = PageRequest.of(0,10);
+        Page<Diagnostic> emptyPage = Page.empty(pageable);
+
+        when(repository.findByDescriptionContainingIgnoreCase(term, pageable)).thenReturn(emptyPage);
+
+        Page<Diagnostic> result = service.getBySearchTerm(term, pageable);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(repository, times(1)).findByDescriptionContainingIgnoreCase(term, pageable);
     }
 }

--- a/src/test/java/com/project/vetdata/service/PostOperativeServiceIT.java
+++ b/src/test/java/com/project/vetdata/service/PostOperativeServiceIT.java
@@ -14,11 +14,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -124,5 +128,43 @@ public class PostOperativeServiceIT {
 
         List<String> names = result.stream().map(PostOperative::getDescription).toList();
         assertTrue(names.contains("Fisioterapia"));
+    }
+
+    @Test
+    public void given_multiple_postOperatives_when_getAllPostOperativesPaginated_then_return_paginated_postOperatives() {
+        service.createPostOperative(PostOperativeTemplate.getFakePostOperativeCreateDTO());
+        service.createPostOperative(PostOperativeTemplate.getFakePostOperativeCreateDTO2());
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("description"));
+        Page<PostOperative> result = service.getAllPostOperativesPaginated(pageable);
+
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertFalse(result.isEmpty(), "A página não deve estar vazia");
+    }
+
+    @Test
+    public void given_postOperatives_when_getBySearchTerm_with_matching_term_then_return_filtered_page() {
+        service.createPostOperative(PostOperativeTemplate.getFakePostOperativeCreateDTO());
+        service.createPostOperative(PostOperativeTemplate.getFakePostOperativeCreateDTO2());
+
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<PostOperative> result = service.getBySearchTerm("fisiote", pageable);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertTrue(result.getContent().get(0).getDescription().toLowerCase().contains("fisiote"));
+    }
+
+    @Test
+    public void given_postOperatives_when_getBySearchTerm_with_no_match_then_return_empty_page() {
+        service.createPostOperative(PostOperativeTemplate.getFakePostOperativeCreateDTO());
+        service.createPostOperative(PostOperativeTemplate.getFakePostOperativeCreateDTO2());
+
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<PostOperative> result = service.getBySearchTerm("Man", pageable);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty(), "A página deve estar vazia");
     }
 }

--- a/src/test/java/com/project/vetdata/service/PostOperativeServiceTest.java
+++ b/src/test/java/com/project/vetdata/service/PostOperativeServiceTest.java
@@ -10,6 +10,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Collections;
 import java.util.List;
@@ -73,5 +77,52 @@ public class PostOperativeServiceTest {
         assertNotNull(result, "A lista não deve ser nula.");
         assertTrue(result.isEmpty(), "A lista deve estar vazia");
         verify(repository, times(1)).findAll();
+    }
+
+    @Test
+    public void given_postOperative_exist_when_getAllPostOperativePaginated_is_called_then_return_page_of_postOperatives() {
+        Pageable pageable = PageRequest.of(0,10);
+        PostOperative postOperative = PostOperativeTemplate.getFakePostOperative();
+        Page<PostOperative> postOperativePage = new PageImpl<>(List.of(postOperative));
+
+        when(repository.findAll(pageable)).thenReturn(postOperativePage);
+
+        Page<PostOperative> result = service.getAllPostOperativesPaginated(pageable);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(repository, times(1)).findAll(pageable);
+    }
+
+    @Test
+    public void given_matching_postOperatives_when_getBySearchTerm_is_called_then_return_page_of_matching_postOperatives() {
+        String term = "fisioterapia";
+        Pageable pageable = PageRequest.of(0,10);
+        PostOperative postOperative = PostOperativeTemplate.getFakePostOperative();
+        Page<PostOperative> postOperativePage = new PageImpl<>(List.of(postOperative));
+
+        when(repository.findByDescriptionContainingIgnoreCase(term, pageable)).thenReturn(postOperativePage);
+
+        Page<PostOperative> result = service.getBySearchTerm(term, pageable);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.getTotalElements());
+        verify(repository, times(1)).findByDescriptionContainingIgnoreCase(term, pageable);
+    }
+
+    @Test
+    public void given_no_matching_postOperatives_when_getBySearchTerm_is_called_then_return_empty_page() {
+        String term = "teste";
+        Pageable pageable = PageRequest.of(0,10);
+        Page<PostOperative> emptyPage = Page.empty(pageable);
+
+        when(repository.findByDescriptionContainingIgnoreCase(term, pageable)).thenReturn(emptyPage);
+
+        Page<PostOperative> result = service.getBySearchTerm(term, pageable);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(repository, times(1)).findByDescriptionContainingIgnoreCase(term, pageable);
     }
 }

--- a/src/test/java/com/project/vetdata/templates/DiagnosticTemplate.java
+++ b/src/test/java/com/project/vetdata/templates/DiagnosticTemplate.java
@@ -9,9 +9,18 @@ public final class DiagnosticTemplate {
         return new DiagnosticCreateDTO("Cancer", "test");
     }
 
+    public static DiagnosticCreateDTO getFakeDiagnosticCreateDTO2() {
+        return new DiagnosticCreateDTO("Gripe", "test");
+    }
+
     public static Diagnostic getFakeDiagnostic() {
         return new Diagnostic("Cancer", "test");
     }
+
+    public static Diagnostic getFakeDiagnostic2() {
+        return new Diagnostic("Gripe", "test");
+    }
+
 
     public static DiagnosticCreateDTO getFakeDiagnosticCreateDTOWithInvalidDescription() {
         return new DiagnosticCreateDTO();

--- a/src/test/java/com/project/vetdata/templates/PostOperativeTemplate.java
+++ b/src/test/java/com/project/vetdata/templates/PostOperativeTemplate.java
@@ -11,8 +11,16 @@ public final class PostOperativeTemplate {
         return new PostOperativeCreateDTO("Fisioterapia");
     }
 
+    public static PostOperativeCreateDTO getFakePostOperativeCreateDTO2() {
+        return new PostOperativeCreateDTO("Repouso");
+    }
+
     public static PostOperative getFakePostOperative() {
         return new PostOperative("Fisioterapia");
+    }
+
+    public static PostOperative getFakePostOperative2() {
+        return new PostOperative("Repouso");
     }
 
     public static PostOperativeCreateDTO getFakePostOperativeCreateDTOWithInvalidDescription() {


### PR DESCRIPTION
# Created search endpoint with pagination in Post Operative

## Type
- [ ] Hotfix
- [x] New feature
- [ ] Refactor / Improvements

## Context
- Criado novo endpoint GET /post-operatives/search com suporte a paginação e busca.
- Utilizado Pageable, PageRequest e Sort para facilitar paginação e ordenação.

### Coverage Tests
![2](https://github.com/user-attachments/assets/ef5eb88a-5fbc-45e0-a700-f88ed97deeee)


### Checklist
- [x] Criar método getAllPostOperativesPaginated no controller.
- [x] Criar testes unitários e de integração.
- [x] Criar documentação Swagger corretamente.