### PR TITLE
Configure Spring Security basic setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,15 @@
             <artifactId>password4j</artifactId>
             <version>1.6.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/com/project/vetdata/configs/SecurityConfig.java
+++ b/src/main/java/com/project/vetdata/configs/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.project.vetdata.configs;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/css/**", "/js/**", "/img/**", "/webjars/**").permitAll()
+                        .requestMatchers(
+                                "/",
+                                "/login",
+                                "/authentications",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form
+                        .loginPage("/login")
+                        .defaultSuccessUrl("/users-pages/list", true)
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/authentications/logout")
+                        .logoutSuccessUrl("/login?logout")
+                        .invalidateHttpSession(true)
+                        .deleteCookies("JSESSIONID")
+                )
+                .sessionManagement(session -> {
+                    session
+                            .maximumSessions(1)
+                            .expiredUrl("/login?expired");
+                    session
+                            .invalidSessionUrl("/login?invalid")
+                            .sessionFixation().migrateSession();
+                })
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new LoginUrlAuthenticationEntryPoint("/login"))
+                )
+                .csrf(csrf -> csrf.disable());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/project/vetdata/controller/AuthenticationController.java
+++ b/src/main/java/com/project/vetdata/controller/AuthenticationController.java
@@ -13,8 +13,13 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.Map;
 
 @RestController
@@ -37,8 +42,14 @@ public class AuthenticationController {
     @PostMapping
     public ResponseEntity<AuthenticationResponseDTO> authenticate(@RequestBody @Valid AuthenticationRequestDTO dto, HttpSession session) {
         AuthenticationResponseDTO response = authenticationService.authenticate(dto);
-        if (response.status().equals(AuthenticationStatus.AUTHORIZED)){
+        if (response.status().equals(AuthenticationStatus.AUTHORIZED)) {
             session.setAttribute("user", response.name());
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    dto.email(), null, Collections.emptyList()
+            );
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(authentication);
+            session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
         }
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/project/vetdata/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/project/vetdata/service/AuthenticationServiceImpl.java
@@ -5,7 +5,11 @@ import com.project.vetdata.dto.AuthenticationRequestDTO;
 import com.project.vetdata.dto.AuthenticationResponseDTO;
 import com.project.vetdata.enums.AuthenticationStatus;
 import com.project.vetdata.repository.UserRepository;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class AuthenticationServiceImpl implements AuthenticationService {
@@ -23,6 +27,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
                     boolean passwordOk = Password.check(dto.password(), user.getPassword()).withBcrypt();
 
                     if (passwordOk) {
+                        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                                user.getEmail(),
+                                null,
+                                List.of()
+                        );
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
                         return new AuthenticationResponseDTO(AuthenticationStatus.AUTHORIZED, user.getName());
                     } else {
                         return new AuthenticationResponseDTO(AuthenticationStatus.NOT_AUTHORIZED, null);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,5 @@ springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 
 external.api.url=https://dogapi.dog/api/v2/breeds
+
+server.servlet.session.timeout=1800

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -217,6 +217,9 @@
                     url: "/authentications",
                     contentType: "application/json",
                     data: JSON.stringify(formData),
+                    xhrFields: {
+        withCredentials: true
+    },
                     success: function (response) {
                         if (response.status === "AUTHORIZED"){
                             window.location.href = "/breeds-pages/list"

--- a/src/test/java/com/project/vetdata/configs/TestSecurityConfig.java
+++ b/src/test/java/com/project/vetdata/configs/TestSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.project.vetdata.configs;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class TestSecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}
+

--- a/src/test/java/com/project/vetdata/controller/AuthenticationRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/AuthenticationRestControllerTest.java
@@ -1,0 +1,100 @@
+package com.project.vetdata.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.configs.TestSecurityConfig;
+import com.project.vetdata.dto.AuthenticationRequestDTO;
+import com.project.vetdata.dto.AuthenticationResponseDTO;
+import com.project.vetdata.enums.AuthenticationStatus;
+import com.project.vetdata.service.AuthenticationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuthenticationController.class)
+@Import(TestSecurityConfig.class)
+public class AuthenticationRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuthenticationService authenticationService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void given_valid_credentials_when_login_then_returns_authorized() throws Exception {
+        AuthenticationRequestDTO requestDTO = new AuthenticationRequestDTO("aline@vetdata.com", "Senha%1");
+        AuthenticationResponseDTO responseDTO = new AuthenticationResponseDTO(AuthenticationStatus.AUTHORIZED, "Aline");
+
+        when(authenticationService.authenticate(eq(requestDTO)))
+                .thenReturn(responseDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/authentications")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("AUTHORIZED"))
+                .andExpect(jsonPath("$.name").value("Aline"));
+
+        verify(authenticationService).authenticate(eq(requestDTO));
+    }
+
+    @Test
+    public void given_invalid_email_when_login_then_returns_not_authorized() throws Exception {
+        AuthenticationRequestDTO requestDTO = new AuthenticationRequestDTO("andrea@vetdata.com", "Senha%1");
+        AuthenticationResponseDTO responseDTO = new AuthenticationResponseDTO(AuthenticationStatus.NOT_AUTHORIZED, null);
+
+        when(authenticationService.authenticate(eq(requestDTO)))
+                .thenReturn(responseDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/authentications")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("NOT_AUTHORIZED"))
+                .andExpect(jsonPath("$.name").doesNotExist());
+
+        verify(authenticationService).authenticate(eq(requestDTO));
+
+    }
+
+    @Test
+    public void given_invalid_password_when_login_then_returns_not_authorized() throws Exception {
+        AuthenticationRequestDTO requestDTO = new AuthenticationRequestDTO("aline@vetdata.com", "Senha%2");
+        AuthenticationResponseDTO responseDTO = new AuthenticationResponseDTO(AuthenticationStatus.NOT_AUTHORIZED, null);
+
+        when(authenticationService.authenticate(eq(requestDTO)))
+                .thenReturn(responseDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/authentications")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("NOT_AUTHORIZED"))
+                .andExpect(jsonPath("$.name").doesNotExist());
+
+        verify(authenticationService).authenticate(eq(requestDTO));
+    }
+
+    @Test
+    public void given_blank_fields_when_login_then_returns_badRequest() throws Exception {
+        AuthenticationRequestDTO requestDTO = new AuthenticationRequestDTO("", "");
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/authentications")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/project/vetdata/controller/DiagnosticRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/DiagnosticRestControllerTest.java
@@ -1,12 +1,14 @@
 package com.project.vetdata.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.model.Diagnostic;
 import com.project.vetdata.service.DiagnosticService;
 import com.project.vetdata.templates.DiagnosticTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -17,13 +19,16 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+
 import java.util.List;
 
 import static org.mockito.Mockito.*;
+import org.springframework.security.test.context.support.WithMockUser;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(DiagnosticRestController.class)
+@Import(TestSecurityConfig.class)
 public class DiagnosticRestControllerTest {
 
     @Autowired
@@ -100,5 +105,4 @@ public class DiagnosticRestControllerTest {
 
         verify(diagnosticService).getAllDiagnosticsPaginated(eq(paging));
     }
-
 }

--- a/src/test/java/com/project/vetdata/controller/DogBreedRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/DogBreedRestControllerTest.java
@@ -1,6 +1,7 @@
 package com.project.vetdata.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.dto.*;
 import com.project.vetdata.model.DogBreed;
 import com.project.vetdata.service.DogBreedExternalService;
@@ -12,8 +13,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.*;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -26,14 +29,13 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
 @WebMvcTest(DogBreedRestController.class)
+@Import(TestSecurityConfig.class)
 public class DogBreedRestControllerTest {
-
-    @InjectMocks
-    private DogBreedServiceImpl dogBreedServiceImpl;
 
     @Autowired
     private MockMvc mockMvc;
@@ -44,16 +46,8 @@ public class DogBreedRestControllerTest {
     @MockitoBean
     private DogBreedExternalService dogBreedExternalService;
 
-    @InjectMocks
-    private DogBreedRestController dogBreedController;
-
     @Autowired
     private ObjectMapper objectMapper;
-
-    @BeforeEach
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Test
     public void given_validDogBreed_when_createDogBreed_then_returnsCreatedDogBreed() throws Exception {

--- a/src/test/java/com/project/vetdata/controller/HealthRecordRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/HealthRecordRestControllerTest.java
@@ -1,5 +1,6 @@
 package com.project.vetdata.controller;
 
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.dto.HealthRecordCreateDTO;
 import com.project.vetdata.dto.HealthRecordUpdateDTO;
 import com.project.vetdata.enums.DogSize;
@@ -13,8 +14,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.*;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -36,6 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(HealthRecordRestController.class)
 @ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
 public class HealthRecordRestControllerTest {
 
     @Autowired

--- a/src/test/java/com/project/vetdata/controller/HospitalAdmissionControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/HospitalAdmissionControllerTest.java
@@ -1,6 +1,7 @@
 package com.project.vetdata.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.dto.HospitalAdmissionCreateDTO;
 import com.project.vetdata.dto.HospitalAdmissionResponseDTO;
 import com.project.vetdata.dto.HospitalAdmissionUpdateDTO;
@@ -11,7 +12,9 @@ import com.project.vetdata.service.HospitalAdmissionService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(HospitalAdmissionController.class)
 @ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
 public class HospitalAdmissionControllerTest {
 
     @Autowired

--- a/src/test/java/com/project/vetdata/controller/PostOperativeRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/PostOperativeRestControllerTest.java
@@ -1,18 +1,21 @@
 package com.project.vetdata.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.model.PostOperative;
 import com.project.vetdata.service.PostOperativeService;
 import com.project.vetdata.templates.PostOperativeTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -24,6 +27,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(PostOperativeRestController.class)
+@Import(TestSecurityConfig.class)
 public class PostOperativeRestControllerTest {
 
     @Autowired

--- a/src/test/java/com/project/vetdata/controller/UserRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/UserRestControllerTest.java
@@ -2,6 +2,7 @@ package com.project.vetdata.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.password4j.Password;
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.dto.UserCreateDTO;
 import com.project.vetdata.model.User;
 import com.project.vetdata.service.UserService;
@@ -9,7 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(UserRestController.class)
 @ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
 public class UserRestControllerTest {
 
     @Autowired


### PR DESCRIPTION
# Configure Spring Security basic setup
## Type,
- [ ] Hotfix,
- [x] New feature,
- [ ] Refactor / Improvements,

## Context,
- Permissão para recursos públicos (estáticos, login, Swagger etc.).
- Controle de sessões com limitação e redirecionamento em caso de sessão inválida ou expirada.
- Desativação de CSRF para facilitar testes com ferramentas externas.
- Redirecionamento para /login em caso de tentativa de acesso sem autenticação.

## Coverage Tests,
![2](https://github.com/user-attachments/assets/2d4e758c-a795-40c6-bd85-3bbef68edc4a)


## Checklist,
- [x] Criar classe SecurityConfig com configurações de segurança da aplicação.
- [x] Permitir acesso apenas a usuários autenticados para endpoints protegidos.