### PR TITLE
Configure AuthenticationManager for custom authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,15 @@
             <artifactId>password4j</artifactId>
             <version>1.6.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/com/project/vetdata/configs/SecurityConfig.java
+++ b/src/main/java/com/project/vetdata/configs/SecurityConfig.java
@@ -1,15 +1,24 @@
 package com.project.vetdata.configs;
 
+import com.project.vetdata.security.CustomAuthenticationEntryPoint;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    @Autowired
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -30,6 +39,7 @@ public class SecurityConfig {
                         .defaultSuccessUrl("/users-pages/list", true)
                         .permitAll()
                 )
+                .httpBasic(Customizer.withDefaults())
                 .logout(logout -> logout
                         .logoutUrl("/authentications/logout")
                         .logoutSuccessUrl("/login?logout")
@@ -45,10 +55,20 @@ public class SecurityConfig {
                             .sessionFixation().migrateSession();
                 })
                 .exceptionHandling(ex -> ex
-                        .authenticationEntryPoint(new LoginUrlAuthenticationEntryPoint("/login"))
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
                 )
                 .csrf(csrf -> csrf.disable());
 
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception{
+        return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/project/vetdata/configs/SecurityConfig.java
+++ b/src/main/java/com/project/vetdata/configs/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.project.vetdata.configs;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/css/**", "/js/**", "/img/**", "/webjars/**").permitAll()
+                        .requestMatchers(
+                                "/",
+                                "/login",
+                                "/authentications",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form
+                        .loginPage("/login")
+                        .defaultSuccessUrl("/users-pages/list", true)
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/authentications/logout")
+                        .logoutSuccessUrl("/login?logout")
+                        .invalidateHttpSession(true)
+                        .deleteCookies("JSESSIONID")
+                )
+                .sessionManagement(session -> {
+                    session
+                            .maximumSessions(1)
+                            .expiredUrl("/login?expired");
+                    session
+                            .invalidSessionUrl("/login?invalid")
+                            .sessionFixation().migrateSession();
+                })
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new LoginUrlAuthenticationEntryPoint("/login"))
+                )
+                .csrf(csrf -> csrf.disable());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/project/vetdata/configs/SecurityConfig.java
+++ b/src/main/java/com/project/vetdata/configs/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/css/**", "/js/**", "/img/**", "/webjars/**").permitAll()
+                        .requestMatchers("/ajax/**","/data/**","/fonts/**","/sound/**","/xml.gmap/**","/css/**", "/js/**", "/img/**", "/webjars/**").permitAll()
                         .requestMatchers(
                                 "/",
                                 "/login",

--- a/src/main/java/com/project/vetdata/controller/AuthenticationController.java
+++ b/src/main/java/com/project/vetdata/controller/AuthenticationController.java
@@ -13,8 +13,13 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.Map;
 
 @RestController
@@ -37,8 +42,14 @@ public class AuthenticationController {
     @PostMapping
     public ResponseEntity<AuthenticationResponseDTO> authenticate(@RequestBody @Valid AuthenticationRequestDTO dto, HttpSession session) {
         AuthenticationResponseDTO response = authenticationService.authenticate(dto);
-        if (response.status().equals(AuthenticationStatus.AUTHORIZED)){
+        if (response.status().equals(AuthenticationStatus.AUTHORIZED)) {
             session.setAttribute("user", response.name());
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    dto.email(), null, Collections.emptyList()
+            );
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(authentication);
+            session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
         }
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/project/vetdata/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/project/vetdata/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,25 @@
+package com.project.vetdata.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import org.springframework.security.core.AuthenticationException;
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+
+        String acceptHeader = request.getHeader("Accept");
+
+        if (acceptHeader != null && acceptHeader.contains("application/json")) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+        } else {
+            response.sendRedirect("/login");
+        }
+    }
+}

--- a/src/main/java/com/project/vetdata/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/project/vetdata/service/AuthenticationServiceImpl.java
@@ -5,7 +5,11 @@ import com.project.vetdata.dto.AuthenticationRequestDTO;
 import com.project.vetdata.dto.AuthenticationResponseDTO;
 import com.project.vetdata.enums.AuthenticationStatus;
 import com.project.vetdata.repository.UserRepository;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class AuthenticationServiceImpl implements AuthenticationService {
@@ -23,6 +27,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
                     boolean passwordOk = Password.check(dto.password(), user.getPassword()).withBcrypt();
 
                     if (passwordOk) {
+                        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                                user.getEmail(),
+                                null,
+                                List.of()
+                        );
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
                         return new AuthenticationResponseDTO(AuthenticationStatus.AUTHORIZED, user.getName());
                     } else {
                         return new AuthenticationResponseDTO(AuthenticationStatus.NOT_AUTHORIZED, null);

--- a/src/main/java/com/project/vetdata/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/project/vetdata/service/AuthenticationServiceImpl.java
@@ -4,8 +4,10 @@ import com.password4j.Password;
 import com.project.vetdata.dto.AuthenticationRequestDTO;
 import com.project.vetdata.dto.AuthenticationResponseDTO;
 import com.project.vetdata.enums.AuthenticationStatus;
+import com.project.vetdata.model.User;
 import com.project.vetdata.repository.UserRepository;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.*;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
@@ -14,31 +16,33 @@ import java.util.List;
 @Service
 public class AuthenticationServiceImpl implements AuthenticationService {
 
+    private final AuthenticationManager authenticationManager;
     private final UserRepository userRepository;
 
-    public AuthenticationServiceImpl(UserRepository userRepository) {
+    public AuthenticationServiceImpl(AuthenticationManager authenticationManager, UserRepository userRepository) {
+        this.authenticationManager = authenticationManager;
         this.userRepository = userRepository;
     }
 
     @Override
     public AuthenticationResponseDTO authenticate(AuthenticationRequestDTO dto) {
-        return userRepository.findByEmail(dto.email())
-                .map(user -> {
-                    boolean passwordOk = Password.check(dto.password(), user.getPassword()).withBcrypt();
+        try {
+            User user = userRepository.findByEmail(dto.email())
+                    .orElseThrow(() -> new BadCredentialsException("Usuário não encontrado"));
 
-                    if (passwordOk) {
-                        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                                user.getEmail(),
-                                null,
-                                List.of()
-                        );
-                        SecurityContextHolder.getContext().setAuthentication(authentication);
-                        return new AuthenticationResponseDTO(AuthenticationStatus.AUTHORIZED, user.getName());
-                    } else {
-                        return new AuthenticationResponseDTO(AuthenticationStatus.NOT_AUTHORIZED, null);
-                    }
-                })
-                .orElseGet(() -> new AuthenticationResponseDTO(AuthenticationStatus.NOT_AUTHORIZED, null));
+            UsernamePasswordAuthenticationToken authToken =
+                    new UsernamePasswordAuthenticationToken(dto.email(), dto.password());
+
+            authenticationManager.authenticate(authToken);
+
+            return new AuthenticationResponseDTO(AuthenticationStatus.AUTHORIZED, user.getName());
+
+        } catch (BadCredentialsException e) {
+            return new AuthenticationResponseDTO(AuthenticationStatus.NOT_AUTHORIZED, null);
+        } catch (DisabledException e) {
+            return new AuthenticationResponseDTO(AuthenticationStatus.INACTIVE, null);
+        } catch (CredentialsExpiredException e) {
+            return new AuthenticationResponseDTO(AuthenticationStatus.PASSWORD_EXPIRED, null);
+        }
     }
-
 }

--- a/src/main/java/com/project/vetdata/service/CustomUserDetailsService.java
+++ b/src/main/java/com/project/vetdata/service/CustomUserDetailsService.java
@@ -1,0 +1,35 @@
+package com.project.vetdata.service;
+
+
+import com.project.vetdata.model.User;
+import com.project.vetdata.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User appUser = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(appUser.getEmail())
+                .password(appUser.getPassword())
+                .authorities(Collections.emptyList())
+                .build();
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,5 @@ springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 
 external.api.url=https://dogapi.dog/api/v2/breeds
+
+server.servlet.session.timeout=1800

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -217,6 +217,9 @@
                     url: "/authentications",
                     contentType: "application/json",
                     data: JSON.stringify(formData),
+                    xhrFields: {
+        withCredentials: true
+    },
                     success: function (response) {
                         if (response.status === "AUTHORIZED"){
                             window.location.href = "/breeds-pages/list"

--- a/src/test/java/com/project/vetdata/configs/CustomAuthenticationEntryPointTest.java
+++ b/src/test/java/com/project/vetdata/configs/CustomAuthenticationEntryPointTest.java
@@ -1,0 +1,62 @@
+package com.project.vetdata.configs;
+
+import com.project.vetdata.security.CustomAuthenticationEntryPoint;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.AuthenticationException;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CustomAuthenticationEntryPointTest {
+
+    private CustomAuthenticationEntryPoint entryPoint;
+
+    @BeforeEach
+    void setUp() {
+        entryPoint = new CustomAuthenticationEntryPoint();
+    }
+
+    @Test
+    void given_json_accept_header_when_commence_then_send_unauthorized_error() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        AuthenticationException authException = mock(AuthenticationException.class);
+
+        when(request.getHeader("Accept")).thenReturn("application/json");
+
+        entryPoint.commence(request, response, authException);
+
+        verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+
+    @Test
+    void given_html_accept_header_when_commence_then_redirect_to_login() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        AuthenticationException authException = mock(AuthenticationException.class);
+
+        when(request.getHeader("Accept")).thenReturn("text/html");
+
+        entryPoint.commence(request, response, authException);
+
+        verify(response).sendRedirect("/login");
+    }
+
+    @Test
+    void given_no_accept_header_when_commence_then_redirect_to_login() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        AuthenticationException authException = mock(AuthenticationException.class);
+
+        when(request.getHeader("Accept")).thenReturn(null);
+
+        entryPoint.commence(request, response, authException);
+
+        verify(response).sendRedirect("/login");
+    }
+}

--- a/src/test/java/com/project/vetdata/configs/TestSecurityConfig.java
+++ b/src/test/java/com/project/vetdata/configs/TestSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.project.vetdata.configs;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class TestSecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}
+

--- a/src/test/java/com/project/vetdata/controller/AuthenticationRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/AuthenticationRestControllerTest.java
@@ -1,0 +1,100 @@
+package com.project.vetdata.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.configs.TestSecurityConfig;
+import com.project.vetdata.dto.AuthenticationRequestDTO;
+import com.project.vetdata.dto.AuthenticationResponseDTO;
+import com.project.vetdata.enums.AuthenticationStatus;
+import com.project.vetdata.service.AuthenticationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuthenticationController.class)
+@Import(TestSecurityConfig.class)
+public class AuthenticationRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuthenticationService authenticationService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void given_valid_credentials_when_login_then_returns_authorized() throws Exception {
+        AuthenticationRequestDTO requestDTO = new AuthenticationRequestDTO("aline@vetdata.com", "Senha%1");
+        AuthenticationResponseDTO responseDTO = new AuthenticationResponseDTO(AuthenticationStatus.AUTHORIZED, "Aline");
+
+        when(authenticationService.authenticate(eq(requestDTO)))
+                .thenReturn(responseDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/authentications")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("AUTHORIZED"))
+                .andExpect(jsonPath("$.name").value("Aline"));
+
+        verify(authenticationService).authenticate(eq(requestDTO));
+    }
+
+    @Test
+    public void given_invalid_email_when_login_then_returns_not_authorized() throws Exception {
+        AuthenticationRequestDTO requestDTO = new AuthenticationRequestDTO("andrea@vetdata.com", "Senha%1");
+        AuthenticationResponseDTO responseDTO = new AuthenticationResponseDTO(AuthenticationStatus.NOT_AUTHORIZED, null);
+
+        when(authenticationService.authenticate(eq(requestDTO)))
+                .thenReturn(responseDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/authentications")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("NOT_AUTHORIZED"))
+                .andExpect(jsonPath("$.name").doesNotExist());
+
+        verify(authenticationService).authenticate(eq(requestDTO));
+
+    }
+
+    @Test
+    public void given_invalid_password_when_login_then_returns_not_authorized() throws Exception {
+        AuthenticationRequestDTO requestDTO = new AuthenticationRequestDTO("aline@vetdata.com", "Senha%2");
+        AuthenticationResponseDTO responseDTO = new AuthenticationResponseDTO(AuthenticationStatus.NOT_AUTHORIZED, null);
+
+        when(authenticationService.authenticate(eq(requestDTO)))
+                .thenReturn(responseDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/authentications")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("NOT_AUTHORIZED"))
+                .andExpect(jsonPath("$.name").doesNotExist());
+
+        verify(authenticationService).authenticate(eq(requestDTO));
+    }
+
+    @Test
+    public void given_blank_fields_when_login_then_returns_badRequest() throws Exception {
+        AuthenticationRequestDTO requestDTO = new AuthenticationRequestDTO("", "");
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/authentications")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/project/vetdata/controller/DiagnosticRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/DiagnosticRestControllerTest.java
@@ -1,12 +1,14 @@
 package com.project.vetdata.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.model.Diagnostic;
 import com.project.vetdata.service.DiagnosticService;
 import com.project.vetdata.templates.DiagnosticTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -17,13 +19,16 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+
 import java.util.List;
 
 import static org.mockito.Mockito.*;
+import org.springframework.security.test.context.support.WithMockUser;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(DiagnosticRestController.class)
+@Import(TestSecurityConfig.class)
 public class DiagnosticRestControllerTest {
 
     @Autowired
@@ -100,5 +105,4 @@ public class DiagnosticRestControllerTest {
 
         verify(diagnosticService).getAllDiagnosticsPaginated(eq(paging));
     }
-
 }

--- a/src/test/java/com/project/vetdata/controller/DogBreedRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/DogBreedRestControllerTest.java
@@ -1,6 +1,7 @@
 package com.project.vetdata.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.dto.*;
 import com.project.vetdata.model.DogBreed;
 import com.project.vetdata.service.DogBreedExternalService;
@@ -12,8 +13,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.*;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -26,14 +29,13 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
 @WebMvcTest(DogBreedRestController.class)
+@Import(TestSecurityConfig.class)
 public class DogBreedRestControllerTest {
-
-    @InjectMocks
-    private DogBreedServiceImpl dogBreedServiceImpl;
 
     @Autowired
     private MockMvc mockMvc;
@@ -44,16 +46,8 @@ public class DogBreedRestControllerTest {
     @MockitoBean
     private DogBreedExternalService dogBreedExternalService;
 
-    @InjectMocks
-    private DogBreedRestController dogBreedController;
-
     @Autowired
     private ObjectMapper objectMapper;
-
-    @BeforeEach
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Test
     public void given_validDogBreed_when_createDogBreed_then_returnsCreatedDogBreed() throws Exception {

--- a/src/test/java/com/project/vetdata/controller/HealthRecordRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/HealthRecordRestControllerTest.java
@@ -1,5 +1,6 @@
 package com.project.vetdata.controller;
 
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.dto.HealthRecordCreateDTO;
 import com.project.vetdata.dto.HealthRecordUpdateDTO;
 import com.project.vetdata.enums.DogSize;
@@ -13,8 +14,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.*;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -36,6 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(HealthRecordRestController.class)
 @ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
 public class HealthRecordRestControllerTest {
 
     @Autowired

--- a/src/test/java/com/project/vetdata/controller/HospitalAdmissionControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/HospitalAdmissionControllerTest.java
@@ -1,6 +1,7 @@
 package com.project.vetdata.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.dto.HospitalAdmissionCreateDTO;
 import com.project.vetdata.dto.HospitalAdmissionResponseDTO;
 import com.project.vetdata.dto.HospitalAdmissionUpdateDTO;
@@ -11,7 +12,9 @@ import com.project.vetdata.service.HospitalAdmissionService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(HospitalAdmissionController.class)
 @ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
 public class HospitalAdmissionControllerTest {
 
     @Autowired

--- a/src/test/java/com/project/vetdata/controller/PostOperativeRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/PostOperativeRestControllerTest.java
@@ -1,18 +1,21 @@
 package com.project.vetdata.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.model.PostOperative;
 import com.project.vetdata.service.PostOperativeService;
 import com.project.vetdata.templates.PostOperativeTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -24,6 +27,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(PostOperativeRestController.class)
+@Import(TestSecurityConfig.class)
 public class PostOperativeRestControllerTest {
 
     @Autowired

--- a/src/test/java/com/project/vetdata/controller/UserRestControllerTest.java
+++ b/src/test/java/com/project/vetdata/controller/UserRestControllerTest.java
@@ -2,6 +2,7 @@ package com.project.vetdata.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.password4j.Password;
+import com.project.vetdata.configs.TestSecurityConfig;
 import com.project.vetdata.dto.UserCreateDTO;
 import com.project.vetdata.model.User;
 import com.project.vetdata.service.UserService;
@@ -9,7 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(UserRestController.class)
 @ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
 public class UserRestControllerTest {
 
     @Autowired

--- a/src/test/java/com/project/vetdata/service/AuthenticationServiceImplTest.java
+++ b/src/test/java/com/project/vetdata/service/AuthenticationServiceImplTest.java
@@ -11,6 +11,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -19,10 +24,14 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class AuthenticationServiceImplTest {
 
     @InjectMocks
     private AuthenticationServiceImpl authenticationService;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
 
     @Mock
     private UserRepository userRepository;
@@ -43,6 +52,9 @@ public class AuthenticationServiceImplTest {
         AuthenticationRequestDTO dto = new AuthenticationRequestDTO(email, password);
 
         when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(email, password);
+        when(authenticationManager.authenticate(any())).thenReturn(authToken);
 
         AuthenticationResponseDTO response = authenticationService.authenticate(dto);
 
@@ -68,6 +80,7 @@ public class AuthenticationServiceImplTest {
         AuthenticationRequestDTO dto = new AuthenticationRequestDTO(email, wrongPassword);
 
         when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(authenticationManager.authenticate(any())).thenThrow(new BadCredentialsException("Senha incorreta"));
 
         AuthenticationResponseDTO response = authenticationService.authenticate(dto);
 


### PR DESCRIPTION
# Configure AuthenticationManager for custom authentication
## Type,
- [ ] Hotfix,
- [x] New feature,
- [ ] Refactor / Improvements,

## Context,
- Criação do AuthenticationManager centralizado para autenticação manual com UsernamePasswordAuthenticationToken.
- Implementação do CustomUserDetailsService que carrega usuários a partir do banco de dados via UserRepository.
- Desativação de CSRF para facilitar testes com ferramentas externas.
- Redirecionamento automático para /login quando um acesso não autenticado for detectado.

## Coverage Tests,
![2](https://github.com/user-attachments/assets/c526ad04-c682-4c6e-8efd-2a3a734b6b52)


## Checklist,
- [x] Adicionar o AuthenticationManager no projeto.
- [x] Corrigir a resposta que estava dando retornando o HTML.